### PR TITLE
Update code_gen.gd

### DIFF
--- a/godot client/addons/SpacetimeDB/GodotHelpers/code_gen.gd
+++ b/godot client/addons/SpacetimeDB/GodotHelpers/code_gen.gd
@@ -168,7 +168,7 @@ func generate_struct_gdscript(type, module_name) -> String:
 		var meta: String = META_TYPE_MAP.get(field.get("type", ""), "")
 		if not meta.is_empty():
 			meta_data.append("set_meta('bsatn_type_%s', &'%s')" 
-				% [field_name.to_snake_case(), meta])
+				% [field_name, meta])
 		content += "@export var %s: %s\n" % [field_name, field_type]
 		class_fields.append([field_name, field_type])
 	content += "\nfunc _init():\n"


### PR DESCRIPTION
Removed the covert to snake case here. It needs to match the exact property name of the class. This would cause an issue where the serializer would just use the default type.
Correct:
![image](https://github.com/user-attachments/assets/200edff9-0761-48b6-952a-5e8c67e1fb94)
Before:
![image](https://github.com/user-attachments/assets/a3261a3d-92bf-4536-9421-87880e05ba89)

