### PR TITLE
SpacetimeDBConnectionOptions.gd

### DIFF
--- a/godot client/addons/SpacetimeDB/Core/SpacetimeDBClient.gd
+++ b/godot client/addons/SpacetimeDB/Core/SpacetimeDBClient.gd
@@ -12,6 +12,7 @@ class_name SpacetimeDBClient extends Node
 @export var debug_mode:bool = true;
 @export var current_subscriptions:Dictionary[int, PackedStringArray]
 
+var connection_options: SpacetimeDBConnectionOptions
 var pending_subscriptions:Dictionary[int, PackedStringArray]
 
 # --- Components ---
@@ -77,7 +78,7 @@ func initialize_and_connect():
 	add_child(_rest_api)
 
 	# 4. Initialize Connection Handler
-	_connection = SpacetimeDBConnection.new(compression, debug_mode)
+	_connection = SpacetimeDBConnection.new(connection_options)
 	_connection.connected.connect(func(): connected.emit())
 	_connection.disconnected.connect(func(): disconnected.emit())
 	_connection.connection_error.connect(func(c, r): connection_error.emit(c, r))
@@ -213,12 +214,15 @@ func _on_websocket_message_received(bsatn_bytes: PackedByteArray):
 
 # --- Public API ---
 
-func connect_db(host_url:String, database_name:String, compression:SpacetimeDBConnection.CompressionPreference, one_time_token:bool = false, debug_mode:bool = false):
+func connect_db(host_url:String, database_name:String, options: SpacetimeDBConnectionOptions = null):
+	if not options:
+		options = SpacetimeDBConnectionOptions.new()
+	connection_options = options
 	self.base_url = host_url;
 	self.database_name = database_name;
-	self.compression = compression
-	self.one_time_token = one_time_token
-	self.debug_mode = debug_mode
+	self.compression = options.compression
+	self.one_time_token = options.one_time_token
+	self.debug_mode = options.debug_mode
 	if not _is_initialized:
 		initialize_and_connect()
 	elif not _connection.is_connected_db():

--- a/godot client/addons/SpacetimeDB/Core/SpacetimeDBConnection.gd
+++ b/godot client/addons/SpacetimeDB/Core/SpacetimeDBConnection.gd
@@ -2,8 +2,6 @@
 class_name SpacetimeDBConnection extends Node
 
 var _websocket := WebSocketPeer.new()
-@export var inbound_buffer_size: int = 1024 * 1024 * 2 # 2MB
-@export var outbound_buffer_size: int = 1024 * 1024 * 2 # 2MB
 var _target_url: String
 var _token: String
 var _is_connected := false
@@ -24,11 +22,11 @@ signal connection_error(code: int, reason: String)
 signal message_received(data: PackedByteArray) 
 signal total_bytes(sended: int, received: int)
 
-func _init(compression:CompressionPreference, debug_mode:bool):
-	_websocket.inbound_buffer_size = inbound_buffer_size
-	_websocket.outbound_buffer_size = outbound_buffer_size
-	set_compression_preference(compression)
-	self._debug_mode = debug_mode
+func _init(options: SpacetimeDBConnectionOptions):
+	_websocket.inbound_buffer_size = options.inbound_buffer_size
+	_websocket.outbound_buffer_size = options.outbound_buffer_size
+	set_compression_preference(options.compression)
+	self._debug_mode = options.debug_mode
 	set_process(false) # Don't process until connect is called
 	
 func print_log(log_message:String):

--- a/godot client/addons/SpacetimeDB/Core/SpacetimeDBConnectionOptions.gd
+++ b/godot client/addons/SpacetimeDB/Core/SpacetimeDBConnectionOptions.gd
@@ -1,0 +1,12 @@
+class_name SpacetimeDBConnectionOptions extends Resource
+const CompressionPreference = SpacetimeDBConnection.CompressionPreference
+
+var compression: CompressionPreference = CompressionPreference.NONE
+var one_time_token: bool = true
+var debug_mode: bool = false
+var inbound_buffer_size: int = 1024 * 1024 * 2 # 2MB
+var outbound_buffer_size: int = 1024 * 1024 * 2 # 2MB
+
+func set_all_buffer_size(size: int):
+    inbound_buffer_size = size
+    outbound_buffer_size = size

--- a/godot client/addons/SpacetimeDB/Core/SpacetimeDBConnectionOptions.gd.uid
+++ b/godot client/addons/SpacetimeDB/Core/SpacetimeDBConnectionOptions.gd.uid
@@ -1,0 +1,1 @@
+uid://0kr0ftnvrnur


### PR DESCRIPTION
Added a struct for connection options that will be passed into connect_db(). This will include the compression mode, debug mode, one time token and websocket buffer sizes. This object can be expanded for future use and options that may be needed.