### PR TITLE
Fix for ScheduleAt type is not yet being generated #21

### DIFF
--- a/godot client/addons/SpacetimeDB/CoreTypes/RustEnum.gd
+++ b/godot client/addons/SpacetimeDB/CoreTypes/RustEnum.gd
@@ -1,4 +1,4 @@
 class_name RustEnum extends Resource
 
-var value: int = 0
+@export var value: int = 0
 var data: Variant


### PR DESCRIPTION
Reducers that are the target of a scheduler will now not be created for the client reducer calls. There is an option to turn back on adding these.
The codgen will read from a config file for ease of keeping these settings for end users. Codegen will also create the config if missing upon first generation.