### PR TITLE
Transactions completed signal in apply_table_update

### DIFF
--- a/godot client/addons/SpacetimeDB/Core/LocalDatabase.gd
+++ b/godot client/addons/SpacetimeDB/Core/LocalDatabase.gd
@@ -12,7 +12,8 @@ var _primary_key_cache: Dictionary = {}
 signal row_inserted(table_name: String, row: Resource)
 signal row_updated(table_name: String, previous_row: Resource, row: Resource)
 signal row_deleted(table_name: String, row: Resource) 
-signal row_deleted_key(table_name: String, primary_key) 
+signal row_deleted_key(table_name: String, primary_key)
+signal row_transactions_completed(table_name: String)
 
 func _init(row_schemas: Dictionary):
 	self._row_schemas = row_schemas
@@ -107,6 +108,9 @@ func apply_table_update(table_update: TableUpdateData):
 		else:
 			push_warning("LocalDatabase: Tried to delete row with PK '", pk_value, "' from table '", table_update.table_name, "' but it wasn't found.")
 
+	# Emits transactions completed signal when all the transactions from
+	# current table update were completed
+	row_transactions_completed.emit(table_update.table_name)
 
 # --- Access Methods ---
 

--- a/godot client/addons/SpacetimeDB/Core/SpacetimeDBClient.gd
+++ b/godot client/addons/SpacetimeDB/Core/SpacetimeDBClient.gd
@@ -38,6 +38,7 @@ signal row_inserted(table_name: String, row: Resource) # From LocalDatabase
 signal row_updated(table_name: String, previous: Resource, row: Resource) # From LocalDatabase
 signal row_deleted(table_name: String, row: Resource)
 signal row_deleted_key(table_name: String, primary_key) # From LocalDatabase
+signal row_transactions_completed(table_name: String) # From LocalDatabase
 signal reducer_call_response(response: Resource) # TODO: Define response resource
 signal reducer_call_timeout(request_id: int) # TODO: Implement timeout logic
 signal transaction_update_received(update: TransactionUpdateData)
@@ -68,6 +69,7 @@ func initialize_and_connect():
 	_local_db.row_updated.connect(func(tn, p, r) -> void: row_updated.emit(tn, p, r))
 	_local_db.row_deleted.connect(func(tn, r) -> void: row_deleted.emit(tn, r))
 	_local_db.row_deleted_key.connect(func(tn, pk) -> void: row_deleted_key.emit(tn, pk))
+	_local_db.row_transactions_completed.connect(func(tn) -> void: row_transactions_completed.emit(tn))
 	add_child(_local_db) # Add as child if it needs signals
 
 	# 3. Initialize REST API Handler (optional, mainly for token)

--- a/godot client/addons/SpacetimeDB/GodotHelpers/RowReceiver.gd
+++ b/godot client/addons/SpacetimeDB/GodotHelpers/RowReceiver.gd
@@ -11,6 +11,7 @@ var _derived_table_names: Array[String] = []
 signal insert(row: _ModuleTable)
 signal update(prev: _ModuleTable, row: _ModuleTable)
 signal delete(row: _ModuleTable)
+signal transactions_completed
 
 func on_set(schema: _ModuleTable):
 	
@@ -80,6 +81,7 @@ func _ready() -> void:
 	SpacetimeDB.row_inserted.connect(_on_insert)
 	SpacetimeDB.row_updated.connect(_on_update)
 	SpacetimeDB.row_deleted.connect(_on_delete)
+	SpacetimeDB.row_transactions_completed.connect(_on_transactions_completed)
 
 	if not table_to_receive:
 		push_error("No data schema. Node path: ", get_path())
@@ -112,3 +114,8 @@ func _on_delete(_table_name: String, row: _ModuleTable):
 	if _table_name != selected_table_name:
 		return
 	delete.emit(row)
+
+func _on_transactions_completed(table_name: String):
+	if table_name != selected_table_name:
+		return
+	transactions_completed.emit()


### PR DESCRIPTION
This helped me a lot for loading screens where I subscribe to a table where I expect multiple rows but insert or update doesn't support arrays and instead is emitting signals on each update or insert. So emitting this signal at the end of `apply_table_update` function I can ensure every row from that table update or insert is finally completed