### PR TITLE
Added deserialize and serialize for Vector2i

### DIFF
--- a/godot client/addons/SpacetimeDB/Core/BSATNDeserializer.gd
+++ b/godot client/addons/SpacetimeDB/Core/BSATNDeserializer.gd
@@ -193,6 +193,9 @@ func read_vector3(spb: StreamPeerBuffer) -> Vector3:
 func read_vector2(spb: StreamPeerBuffer) -> Vector2:
 	var x := read_f32_le(spb); var y := read_f32_le(spb)
 	return Vector2.ZERO if has_error() else Vector2(x, y)
+func read_vector2i(spb: StreamPeerBuffer) -> Vector2i:
+	var x := read_i32_le(spb); var y := read_i32_le(spb)
+	return Vector2i.ZERO if has_error() else Vector2i(x, y)
 func read_color(spb: StreamPeerBuffer) -> Color:
 	var r := read_f32_le(spb); var g := read_f32_le(spb); var b := read_f32_le(spb); var a := read_f32_le(spb)
 	return Color.BLACK if has_error() else Color(r, g, b, a)
@@ -308,6 +311,7 @@ func _get_reader_callable_for_property(resource: Resource, prop: Dictionary) -> 
 				TYPE_FLOAT: reader_callable = Callable(self, "read_f32_le") # Default float is f32
 				TYPE_STRING: reader_callable = Callable(self, "read_string_with_u32_len")
 				TYPE_VECTOR2: reader_callable = Callable(self, "read_vector2")
+				TYPE_VECTOR2I: reader_callable = Callable(self, "read_vector2i")
 				TYPE_VECTOR3: reader_callable = Callable(self, "read_vector3")
 				TYPE_COLOR: reader_callable = Callable(self, "read_color")
 				TYPE_QUATERNION: reader_callable = Callable(self, "read_quaternion")

--- a/godot client/addons/SpacetimeDB/Core/BSATNSerializer.gd
+++ b/godot client/addons/SpacetimeDB/Core/BSATNSerializer.gd
@@ -113,6 +113,10 @@ func write_vector2(v: Vector2) -> void:
 	if v == null: v = Vector2.ZERO # Handle potential null value
 	write_f32_le(v.x); write_f32_le(v.y)
 
+func write_vector2i(v: Vector2i) -> void:
+	if v == null: v = Vector2i.ZERO # Handle potential null value
+	write_i32_le(v.x); write_i32_le(v.y)
+	
 func write_color(v: Color) -> void:
 	if v == null: v = Color.BLACK # Handle potential null value
 	write_f32_le(v.r); write_f32_le(v.g); write_f32_le(v.b); write_f32_le(v.a)
@@ -239,6 +243,7 @@ func _write_value(value, value_variant_type: Variant.Type, specific_writer_overr
 			TYPE_FLOAT: write_f32_le(value) # Default float serialization is f32
 			TYPE_STRING: write_string_with_u32_len(value)
 			TYPE_VECTOR2: write_vector2(value)
+			TYPE_VECTOR2I: write_vector2i(value)
 			TYPE_VECTOR3: write_vector3(value)
 			TYPE_COLOR: write_color(value)
 			TYPE_QUATERNION: write_quaternion(value)
@@ -395,6 +400,7 @@ func _write_argument_value(value, rust_type: String = "") -> bool:
 				_: write_f32_le(value) # Default f32
 		TYPE_STRING: write_string_with_u32_len(value)
 		TYPE_VECTOR2: write_vector2(value)
+		TYPE_VECTOR2I: write_vector2i(value)
 		TYPE_VECTOR3: write_vector3(value)
 		TYPE_COLOR: write_color(value)
 		TYPE_QUATERNION: write_quaternion(value)
@@ -430,6 +436,7 @@ func _generate_default_type(rust_type: String) -> Variant:
 		&"String": return ""
 		&"Vector3": return Vector3.ZERO
 		&"Vector2": return Vector2.ZERO
+		&"Vector2i": return Vector2i.ZERO
 		&"Color": return Color.BLACK
 		&"Quaternion": return Quaternion.IDENTITY
 		_: return null


### PR DESCRIPTION
Added deserialize and serialize for Vector2i, built on top of some implementation that already existed, the methods to handle Vector2i did not exists. Implemented like so on the server:

#[derive(SpacetimeType, Clone, Copy)]
pub struct Vector2I {
    pub x: i32,
    pub y: i32,
}