### PR TITLE
Always read fallback schema types

### DIFF
--- a/godot-client/addons/SpacetimeDB/codegen/codegen.gd
+++ b/godot-client/addons/SpacetimeDB/codegen/codegen.gd
@@ -569,7 +569,7 @@ func _generate_reducers_gdscript(schema: SpacetimeParsedSchema) -> String:
 		"\tvar __handle__ := _client.call_reducer('%s', [%s], [%s])\n" % \
 		[reducer_name, param_names_str, param_bsatn_types_str] + \
 		"\tif __handle__.error: return __handle__.error\n" + \
-		"\tvar __result__: TransactionUpdateMessage= await __handle__.wait_for_response()\n" + \
+		"\tvar __result__: TransactionUpdateMessage = await __handle__.wait_for_response()\n" + \
 		"\tcb.call(__result__)\n" + \
         "\treturn OK\n\n"
 	

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_schema.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_schema.gd
@@ -63,23 +63,21 @@ func _load_types(raw_path: String, prefix: String = "") -> void:
 				var fallback_table_names: Array[String] = [file_name.get_basename().get_file()]
 				
 				var constants := script.get_script_constant_map()
-				var table_names: Array[String]
-				var is_table := false
-				if constants.has('table_names'):
-					is_table = true
-					table_names = constants['table_names'] as Array[String]
-				else:
-					table_names = fallback_table_names
-
-				for table_name in table_names:
-					var lower_table_name := table_name.to_lower().replace("_", "")
-					if types.has(lower_table_name) and debug_mode:
-						push_warning("SpacetimeDBSchema: Overwriting schema for table '%s' (from %s)" % [table_name, script_path])
-						
-					if is_table:
-						tables[lower_table_name] = script
-					types[lower_table_name] = script
+				
+				var add_table_names = func(table_names: Array[String], is_table: bool) -> void:
+					for table_name in table_names:
+						var lower_table_name := table_name.to_lower().replace("_", "")
+						if types.has(lower_table_name) and debug_mode:
+							push_warning("SpacetimeDBSchema: Overwriting schema for table '%s' (from %s)" % [table_name, script_path])
+							
+						if is_table:
+							tables[lower_table_name] = script
+						types[lower_table_name] = script
 			
+				if constants.has('table_names'):
+					add_table_names.call(constants['table_names'] as Array[String], true)
+				add_table_names.call(fallback_table_names, false)
+
 	dir.list_dir_end()
 
 func get_type(type_name: String) -> GDScript:

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_schema.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_schema.gd
@@ -63,22 +63,22 @@ func _load_types(raw_path: String, prefix: String = "") -> void:
 				var fallback_table_names: Array[String] = [file_name.get_basename().get_file()]
 				
 				var constants := script.get_script_constant_map()
-				
-				var add_table_names = func(table_names: Array[String], is_table: bool) -> void:
-					for table_name in table_names:
-						var lower_table_name := table_name.to_lower().replace("_", "")
-						if types.has(lower_table_name) and debug_mode:
-							push_warning("SpacetimeDBSchema: Overwriting schema for table '%s' (from %s)" % [table_name, script_path])
 							
-						if is_table:
-							tables[lower_table_name] = script
-						types[lower_table_name] = script
-			
 				if constants.has('table_names'):
-					add_table_names.call(constants['table_names'] as Array[String], true)
-				add_table_names.call(fallback_table_names, false)
+					_add_table_names.call(constants['table_names'] as Array[String], true, script, script_path)
+				_add_table_names.call(fallback_table_names, false, script, script_path)
 
 	dir.list_dir_end()
 
 func get_type(type_name: String) -> GDScript:
 	return types.get(type_name)
+
+func _add_table_names(table_names: Array[String], is_table: bool, script: GDScript, script_path: String) -> void:
+	for table_name in table_names:
+		var lower_table_name := table_name.to_lower().replace("_", "")
+		if types.has(lower_table_name) and debug_mode:
+			push_warning("SpacetimeDBSchema: Overwriting schema for table '%s' (from %s)" % [table_name, script_path])
+			
+		if is_table:
+			tables[lower_table_name] = script
+		types[lower_table_name] = script


### PR DESCRIPTION
In the schema, if we get to a type that is a table, we save the type under the table's name.
However, if that type is also a member of another table, we will then not be able to find the type as that type is now hidden behind the table name (and not the actual type name).

e.g.
```
#[table(name = cool_data_table)]
pub struct CoolData {
    #[primary_key]
    pub cool_key: u64,
    pub other_cool_data: u8
}
```
When we parse the spacetime_bindings, this CoolData struct is saved in the schema as `cooldatatable`.

If we then also have a table like
```
#[table(name = some_other_table)]
pub struct other_table {
    #[primary_key]
    pub other_key: u64,
    pub data: CoolData
}
```

Now, when deserializing `other_table`, it would look through the schema and try to find `servernamecooldata` which is how non-table types are stored. My solution is to just always save the types as their non-table name, as well as their table name if they're tables.