### PR TITLE
LocalDB table change signals now only emit after all rows are changed.

### DIFF
--- a/godot-client/.gitignore
+++ b/godot-client/.gitignore
@@ -2,3 +2,4 @@
 .godot/
 /android/
 spacetime_bindings/codegen_debug
+desktop.ini


### PR DESCRIPTION
changelog: 
- local db insert/update/delete signals are only emmited after the complete server message is processed.
  - this is in line with the official client sdk