### PR TITLE
UI tweaks and odd read-only dictionary fix

### DIFF
--- a/godot-client/addons/SpacetimeDB/spacetime.gd
+++ b/godot-client/addons/SpacetimeDB/spacetime.gd
@@ -50,15 +50,15 @@ func _enter_tree():
 	var author: String = config_file.get_value("plugin", "author", "??")
 
 	print_log("SpacetimeDB SDK v%s (c) 2025-present %s & Contributors" % [version, author])
-	print_log("""new module:
+	print_log("""New modules:
 [ul]
-name: required
-alias: optional
-hide scheduled reducer: hides the scheduled reducer from the client
-hide private tables: hides private tables from the client
+Name: Required
+Alias: Optional
+Hide scheduled reducer: Hides the scheduled reducer from the client.
+Hide private tables: Hides private tables from the client.
 [/ul]
 
-after generating the files. please restart godot.
+After generating schema files, please restart Godot.
 """)
 	load_codegen_data()
 
@@ -66,9 +66,8 @@ after generating the files. please restart godot.
 func load_codegen_data() -> void:
 	if ResourceLoader.exists(SAVE_PATH, "SpacetimeDBPluginConfig"):
 		plugin_config = ResourceLoader.load(SAVE_PATH)
-		print_log("Loading codegen data from %s" % [SAVE_PATH])
-	else:
-		print_log("failed to load codegen data from %s" % [SAVE_PATH])
+		print_log("Loaded module configs from %s" % [SAVE_PATH])
+	if plugin_config == null or plugin_config.module_configs.is_empty():
 		plugin_config = SpacetimeDBPluginConfig.new()
 	ui._plugin_config = plugin_config
 	ui.update_module_ui()
@@ -78,7 +77,7 @@ func save_codegen_data() -> void:
 		DirAccess.make_dir_absolute(BINDINGS_PATH)
 		get_editor_interface().get_resource_filesystem().scan()
 	if not plugin_config:
-		ui.add_err("somehow the plugin_config variable is empty")
+		ui.add_err("Somehow the plugin_config variable is empty")
 		plugin_config = SpacetimeDBPluginConfig.new()
 		ui._plugin_config = plugin_config
 		ui.update_module_ui()
@@ -152,7 +151,7 @@ func _on_generate_schema():
 	if not ProjectSettings.has_setting(setting_name):
 		add_autoload_singleton(AUTOLOAD_NAME, AUTOLOAD_PATH)
 	while get_editor_interface().get_resource_filesystem().is_scanning():
-		print_log("waiting for auto scan to finish")
+		print_log("Waiting for auto scan to finish")
 		continue
 	get_editor_interface().get_resource_filesystem().scan()
 	print_log("Code generation complete!")

--- a/godot-client/addons/SpacetimeDB/ui/ui.gd
+++ b/godot-client/addons/SpacetimeDB/ui/ui.gd
@@ -15,33 +15,19 @@ var _new_module_name_input: LineEdit
 var _new_module_alias_input: LineEdit
 var _new_module_reducer_checkbox: CheckBox
 var _new_module_table_checkbox: CheckBox
-var _new_module_button: Button
-var _check_uri_button: Button
 var _generate_button: Button
-var _clear_logs_button: Button
-var _copy_logs_button: Button
 var _plugin_config: SpacetimeDBPluginConfig
 
 func _enter_tree() -> void:
-	_uri_input = $"Main/BottomBar/ServerUri/UriInput"
-	_modules_container = $"Main/Content/Sidebar/Modules/ModulesList/VBox"
-	_logs_label = $"Main/Content/Logs"
-	_add_module_hint_label = $"Main/Content/Sidebar/Modules/AddModuleHint"
-	_new_module_name_input = $Main/Content/Sidebar/PanelContainer2/VBoxContainer/NewModule/VBoxContainer/ModuleNameInput
-	_new_module_alias_input = $Main/Content/Sidebar/PanelContainer2/VBoxContainer/NewModule/VBoxContainer/ModuleAliasInput
-	_new_module_reducer_checkbox = $Main/Content/Sidebar/PanelContainer2/VBoxContainer/ReducerCheckbox
-	_new_module_table_checkbox = $Main/Content/Sidebar/PanelContainer2/VBoxContainer/TablesCheckbox
-	_new_module_button = $Main/Content/Sidebar/PanelContainer2/VBoxContainer/NewModule/AddButton
-	_check_uri_button = $"Main/BottomBar/CheckUri"
-	_generate_button = $"Main/Content/Sidebar/GenerateButton"
-	_clear_logs_button = $"Main/BottomBar/LogsControls/ClearLogsButton"
-	_copy_logs_button = $"Main/BottomBar/LogsControls/CopyLogsButton"
-
-	_check_uri_button.pressed.connect(_on_check_uri)
-	_generate_button.pressed.connect(_on_generate_code)
-	_new_module_button.pressed.connect(_on_new_module)
-	_clear_logs_button.pressed.connect(_on_clear_logs)
-	_copy_logs_button.pressed.connect(_on_copy_selected_logs)
+	_uri_input = %UriInput
+	_modules_container = %ModulesContainer
+	_logs_label = %Logs
+	_add_module_hint_label = %AddModuleHint
+	_new_module_name_input = %ModuleNameInput
+	_new_module_alias_input = %ModuleAliasInput
+	_new_module_reducer_checkbox = %ReducerCheckbox
+	_new_module_table_checkbox = %TablesCheckbox
+	_generate_button = %GenerateButton
 
 func _input(event: InputEvent) -> void:
 	if not visible:
@@ -146,11 +132,7 @@ func destroy() -> void:
 	_add_module_hint_label = null
 	_new_module_name_input = null
 	_new_module_alias_input = null
-	_new_module_button = null
-	_check_uri_button = null
 	_generate_button = null
-	_clear_logs_button = null
-	_copy_logs_button = null
 
 func _on_check_uri() -> void:
 	_plugin_config.uri = _uri_input.text

--- a/godot-client/addons/SpacetimeDB/ui/ui.tscn
+++ b/godot-client/addons/SpacetimeDB/ui/ui.tscn
@@ -131,7 +131,7 @@ text = "Hide scheduled reducer"
 [node name="TableCheckbox" type="CheckBox" parent="Prefabs/ModulePrefab/VBoxContainer" unique_id=1106248549]
 layout_mode = 2
 button_pressed = true
-text = "Hide private Tables"
+text = "Hide private tables"
 
 [node name="Main" type="VBoxContainer" parent="." unique_id=1927142397]
 layout_mode = 1
@@ -148,6 +148,7 @@ size_flags_vertical = 3
 theme_override_constants/separation = 4
 
 [node name="Logs" type="RichTextLabel" parent="Main/Content" unique_id=776566878]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 9)
 layout_mode = 2
 size_flags_horizontal = 3
@@ -172,74 +173,77 @@ custom_minimum_size = Vector2(250, 0)
 layout_mode = 2
 theme_override_constants/separation = 4
 
-[node name="ModulesLabel" type="Label" parent="Main/Content/Sidebar" unique_id=1554960587]
-layout_mode = 2
-text = "Modules"
-horizontal_alignment = 1
-
-[node name="Modules" type="Control" parent="Main/Content/Sidebar" unique_id=2077860174]
-self_modulate = Color(1, 1, 1, 0)
+[node name="ScrollContainer" type="ScrollContainer" parent="Main/Content/Sidebar" unique_id=1958680145]
+custom_minimum_size = Vector2(250, 0)
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="AddModuleHint" type="RichTextLabel" parent="Main/Content/Sidebar/Modules" unique_id=1922651127]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_styles/normal = SubResource("StyleBoxEmpty_d0lf3")
-bbcode_enabled = true
-text = "Add a module by entering the name below and clicking [img]res://addons/SpacetimeDB/ui/icons/Add.svg[/img]"
-scroll_active = false
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="ModulesList" type="ScrollContainer" parent="Main/Content/Sidebar/Modules" unique_id=158256308]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-size_flags_vertical = 3
-
-[node name="VBox" type="VBoxContainer" parent="Main/Content/Sidebar/Modules/ModulesList" unique_id=1083011433]
+[node name="VBoxContainer" type="VBoxContainer" parent="Main/Content/Sidebar/ScrollContainer" unique_id=288646920]
+custom_minimum_size = Vector2(250, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="PanelContainer2" type="PanelContainer" parent="Main/Content/Sidebar" unique_id=470251646]
+[node name="ModulesLabel" type="Label" parent="Main/Content/Sidebar/ScrollContainer/VBoxContainer" unique_id=1554960587]
+layout_mode = 2
+text = "Modules"
+horizontal_alignment = 1
+
+[node name="AddModuleHint" type="RichTextLabel" parent="Main/Content/Sidebar/ScrollContainer/VBoxContainer" unique_id=1922651127]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_styles/normal = SubResource("StyleBoxEmpty_d0lf3")
+bbcode_enabled = true
+text = "Add a module by entering the name below and clicking [img]res://addons/SpacetimeDB/ui/icons/Add.svg[/img]"
+fit_content = true
+scroll_active = false
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="ModulesContainer" type="VBoxContainer" parent="Main/Content/Sidebar/ScrollContainer/VBoxContainer" unique_id=1083011433]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="ModulesLabel2" type="Label" parent="Main/Content/Sidebar/ScrollContainer/VBoxContainer" unique_id=1852514859]
+layout_mode = 2
+text = "Add New Module"
+horizontal_alignment = 1
+
+[node name="PanelContainer2" type="PanelContainer" parent="Main/Content/Sidebar/ScrollContainer/VBoxContainer" unique_id=470251646]
 custom_minimum_size = Vector2(245, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_styles/panel = SubResource("StyleBoxFlat_ej8d4")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Main/Content/Sidebar/PanelContainer2" unique_id=731307918]
+[node name="VBoxContainer" type="VBoxContainer" parent="Main/Content/Sidebar/ScrollContainer/VBoxContainer/PanelContainer2" unique_id=731307918]
 layout_mode = 2
 
-[node name="NewModule" type="HBoxContainer" parent="Main/Content/Sidebar/PanelContainer2/VBoxContainer" unique_id=133310361]
+[node name="NewModule" type="HBoxContainer" parent="Main/Content/Sidebar/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer" unique_id=133310361]
 self_modulate = Color(1, 1, 1, 0)
 custom_minimum_size = Vector2(0, 35)
 layout_mode = 2
 theme_override_constants/separation = 5
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Main/Content/Sidebar/PanelContainer2/VBoxContainer/NewModule" unique_id=157228287]
+[node name="VBoxContainer" type="VBoxContainer" parent="Main/Content/Sidebar/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/NewModule" unique_id=157228287]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="ModuleNameInput" type="LineEdit" parent="Main/Content/Sidebar/PanelContainer2/VBoxContainer/NewModule/VBoxContainer" unique_id=352108602]
+[node name="ModuleNameInput" type="LineEdit" parent="Main/Content/Sidebar/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/NewModule/VBoxContainer" unique_id=352108602]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 placeholder_text = "Enter module name"
 
-[node name="ModuleAliasInput" type="LineEdit" parent="Main/Content/Sidebar/PanelContainer2/VBoxContainer/NewModule/VBoxContainer" unique_id=191976263]
+[node name="ModuleAliasInput" type="LineEdit" parent="Main/Content/Sidebar/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/NewModule/VBoxContainer" unique_id=191976263]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 placeholder_text = "Enter Alias name"
 
-[node name="AddButton" type="Button" parent="Main/Content/Sidebar/PanelContainer2/VBoxContainer/NewModule" unique_id=1405223987]
+[node name="AddButton" type="Button" parent="Main/Content/Sidebar/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/NewModule" unique_id=1405223987]
 custom_minimum_size = Vector2(26, 27)
 layout_mode = 2
 size_flags_horizontal = 8
@@ -250,17 +254,20 @@ theme_override_styles/focus = SubResource("StyleBoxEmpty_k511v")
 icon = ExtResource("2_3cpcg")
 icon_alignment = 1
 
-[node name="ReducerCheckbox" type="CheckBox" parent="Main/Content/Sidebar/PanelContainer2/VBoxContainer" unique_id=1426498162]
+[node name="ReducerCheckbox" type="CheckBox" parent="Main/Content/Sidebar/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer" unique_id=1426498162]
+unique_name_in_owner = true
 layout_mode = 2
 button_pressed = true
 text = "Hide scheduled reducer"
 
-[node name="TablesCheckbox" type="CheckBox" parent="Main/Content/Sidebar/PanelContainer2/VBoxContainer" unique_id=1656566781]
+[node name="TablesCheckbox" type="CheckBox" parent="Main/Content/Sidebar/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer" unique_id=1656566781]
+unique_name_in_owner = true
 layout_mode = 2
 button_pressed = true
-text = "Hide private Tables"
+text = "Hide private tables"
 
 [node name="GenerateButton" type="Button" parent="Main/Content/Sidebar" unique_id=1719959949]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 31)
 layout_mode = 2
 disabled = true
@@ -307,6 +314,7 @@ text = "Server URI:"
 vertical_alignment = 1
 
 [node name="UriInput" type="LineEdit" parent="Main/BottomBar/ServerUri" unique_id=134731222]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "http://127.0.0.1:3000"
@@ -315,3 +323,9 @@ placeholder_text = "Enter the server URI"
 [node name="CheckUri" type="Button" parent="Main/BottomBar" unique_id=741931029]
 layout_mode = 2
 text = "Check URI"
+
+[connection signal="pressed" from="Main/Content/Sidebar/ScrollContainer/VBoxContainer/PanelContainer2/VBoxContainer/NewModule/AddButton" to="." method="_on_new_module"]
+[connection signal="pressed" from="Main/Content/Sidebar/GenerateButton" to="." method="_on_generate_code"]
+[connection signal="pressed" from="Main/BottomBar/LogsControls/ClearLogsButton" to="." method="_on_clear_logs"]
+[connection signal="pressed" from="Main/BottomBar/LogsControls/CopyLogsButton" to="." method="_on_copy_selected_logs"]
+[connection signal="pressed" from="Main/BottomBar/CheckUri" to="." method="_on_check_uri"]


### PR DESCRIPTION
Issues found when testing that are now fixed:

- Some capitalization and word choice
- Error on editor startup from UI buttons being connected twice, fixed by connecting buttons through inspector rather than manually in _enter_tree
- Removed message saying module configs couldn't be loaded, since that will happen to anyone using the plugin for the first time and we don't want to scare them
- UI tweaks to module list, putting existing modules and the "add new module" section in a join scrollbox, so that existing modules don't hide behind the new-module node with no indication that they're there, in case the window is at minimum height.
- Weird Godot issue where, if plugin_config.tres exists but has no modules in it (because they were removed), no module can be added because the module dictionary is in a read-only mode. This for some reason only happens when starting the editor, and only if the module dictionary is empty. Fixed this by making a whole new plugin config instance if the loaded one is empty.