### PR TITLE
Reducer code overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
   <img src="https://github.com/user-attachments/assets/41dd6587-9f3c-45cd-b6b4-e144dc4338ac" alt="godot-spacetimedb_128" width="128">
 </p>
 
-## SpacetimeDB Godot SDK
+## SpacetimeDB Godot SDK for SpacetimeDB 2.x+
 
-> Tested with: `Godot 4.4.1-stable` to `Godot 4.6.beta3` and `SpacetimeDB 1.8.0` to `SpacetimeDB 1.11.2`
+> Tested with: `Godot 4.6.1` and `SpacetimeDB 2.x+`
 
 This SDK provides the necessary tools to integrate your Godot Engine project with a SpacetimeDB backend, enabling real-time data synchronization and server interaction directly from your Godot client.
 
@@ -17,11 +17,12 @@ This SDK provides the necessary tools to integrate your Godot Engine project wit
 ## Limitations & TODO
 
 -   **Option<T> and Vec<T>** Currently limited to 1 layer of nesting: Option<Vec<T>>, Vec<Option<T>> only. No Option<Option<T>> or Vec<Vec<T>> etc...
--   **Error Handling:** Can be improved, especially for reducer call failures beyond basic connection errors.
+-   **Error Handling:** Can be improved
 -   **Configuration:** More options could be added (timeouts, reconnection).
 -   **Compression:** Brotli - not supported.
 -   **Tables and Views without Primary_key:** only the Insert and Delete callbacks get called. Data will not be saved inside the local DB.
--   **Procedures**: not supported
+-   **Procedures**: not supported (waiting for a PR for SpacetimeDB to release)
+-   **Event Tables**: not supported (waiting for a PR for SpacetimeDB to release)
 
 ## Contributing
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -188,15 +188,33 @@ Use the generated module bindings to trigger server-side logic.
 ```gdscript
 func move_player(direction: Vector2):
     if not SpacetimeDB.MyModule.is_connected_db(): return
+    
+    # Reducer call returns a call object that the response will use to send out it's callback signals
+    var call : SpacetimeDBReducerCall = SpacetimeDB.MyModule.reducers.example_reducer()
+    
+    # checking if the reducer call was send out successfully
+    if call.error:
+        # handle reducer call error
+        pass
+    
+    # general callback signal
+    call.response.connect(func(update:ReducerResultMessage) -> void: pass)
+    
+    # reducer successfully ran and returned with data (general subscription data)
+    call.on_ok.connect(func(update:ReducerResultMessage) -> void: pass)
+    
+    # reducer successfully ran and returned without data
+    call.on_ok_empty.connect(func(update:ReducerResultMessage) -> void: pass)
+    
+    # reducer failed to run and returned with the error string
+    call.on_error.conect(func(err: String) -> void: pass)
+    
+    # reducer failed with internal error. not expected to be ever called.
+    call.on_internal_error.conect(func(err: String) -> void: pass)
+    
+    # waiting for the reducer response
+    await call1.response
 
-    # You can use callback, but it doesn`t required
-    # Example with callback
-    SpacetimeDB.MyModule.reducers.move_user(direction, global_position, func(tx: TransactionUpdateData):
-        print("Result:", tx)
-    )
-
-    # Example without callback
-    SpacetimeDB.MyModule.reducers.move_user(direction, global_position)
 ```
 
 ## Query Local Database

--- a/godot-client/addons/SpacetimeDB/codegen/codegen.gd
+++ b/godot-client/addons/SpacetimeDB/codegen/codegen.gd
@@ -526,9 +526,9 @@ func _generate_reducers_gdscript(module_name: String, schema: SpacetimeParsedSch
 
 		var params_str: String
 		if params_str_parts.is_empty():
-			params_str = "cb: Callable = func(_t: TransactionUpdateMessage) -> void: pass"
+			params_str = ""
 		else:
-			params_str = ", ".join(params_str_parts) + ", cb: Callable = func(_t: TransactionUpdateMessage) -> void: pass"
+			params_str = ", ".join(params_str_parts)
 
 		var param_names_list = reducer.get("params", []).map(func(x): return x.get("name", ""))
 		var param_names_str = ""
@@ -566,16 +566,10 @@ func _generate_reducers_gdscript(module_name: String, schema: SpacetimeParsedSch
 
 		content += "\n".join(description_comment) + "\n"
 		var reducer_name: String = reducer.get("name", "")
-		content += "func %s(%s) -> Error:\n" % [reducer_name, params_str] + \
-		"\tvar __handle__ : SpacetimeDBReducerCall = _client.call_reducer('%s', [%s], [%s])\n" % \
-		[reducer_name, param_names_str, param_bsatn_types_str] + \
-		"\tif __handle__.error: return __handle__.error\n" + \
-		"\tvar __result__: TransactionUpdateMessage = await __handle__.wait_for_response()\n" + \
-		"\tif cb.is_valid():\n" + \
-		"\t\tcb.call(__result__)\n" + \
-		"\telse:\n" + \
-		"\t\treturn ERR_METHOD_NOT_FOUND\n" + \
-		"\treturn OK\n\n"
+		content += "func %s(%s) -> SpacetimeDBReducerCall:\n" % [reducer_name, params_str] + \
+		"\treturn _client.call_reducer('%s', [%s], [%s])\n\n" % \
+		[reducer_name, param_names_str, param_bsatn_types_str]
+
 
 	return content
 

--- a/godot-client/addons/SpacetimeDB/codegen/codegen.gd
+++ b/godot-client/addons/SpacetimeDB/codegen/codegen.gd
@@ -426,7 +426,36 @@ func _generate_module_client_gdscript(module_name: String, schema: SpacetimePars
 	if not types_part.is_empty():
 		content += types_part + "\n"
 
-	content += "var reducers: %sModuleReducers\n" % schema.module.to_pascal_case() + \
+	content += "
+## example usage:
+## [codeblock]
+## # Reducer call returns a call object that the response will use to send out it's callback signals
+## var call : SpacetimeDBReducerCall = SpacetimeDB.%s.reducers.example_reducer()
+##
+## # checking if the reducer call was send out successfully
+## if call.error:
+##     # handle reducer call error
+##     pass
+##
+## # general callback signal
+## call.response.connect(func(update:ReducerResultMessage) -> void: pass)
+##
+## # reducer successfully ran and returned with data (general subscription data)
+## call.on_ok.connect(func(update:ReducerResultMessage) -> void: pass)
+##
+## # reducer successfully ran and returned without data
+## call.on_ok_empty.connect(func(update:ReducerResultMessage) -> void: pass)
+##
+## # reducer failed to run and returned with the error string
+## call.on_error.conect(func(err: String) -> void: pass)
+##
+## # reducer failed with internal error. not expected to be ever called.
+## call.on_internal_error.conect(func(err: String) -> void: pass)
+##
+## waiting for the reducer response
+## await call.response
+## [/codeblock]\n" % schema.module.to_pascal_case() + \
+	"var reducers: %sModuleReducers\n" % schema.module.to_pascal_case() + \
 	"var db: %sModuleDb\n\n" % schema.module.to_pascal_case() + \
 	"func _init() -> void:\n" + \
 	"\tset_meta(\"module_name\", \"%s\")\n" % schema.module + \

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
@@ -24,8 +24,7 @@ var _thread_should_exit: bool = false
 var _message_limit_in_frame: int = 5
 
 var connection_options: SpacetimeDBConnectionOptions
-var pending_subscriptions: Dictionary[int, SpacetimeDBSubscription]
-var pending_one_off_query_callbacks: Dictionary[int,Callable]
+
 
 # --- Components ---
 var _connection: SpacetimeDBConnection
@@ -42,7 +41,9 @@ var _is_initialized := false
 var _received_initial_subscription := false
 var _next_query_id := 0
 var _next_request_id := 0
-var _request_id_to_reducer_name: Dictionary[int, String] = { }
+var _pending_reducer_call: Dictionary[int, SpacetimeDBReducerCall] = { }
+var _pending_subscriptions: Dictionary[int, SpacetimeDBSubscription]
+var _pending_one_off_query_callbacks: Dictionary[int,Callable]
 
 # --- Signals ---
 signal connected(identity: PackedByteArray, token: String)
@@ -284,9 +285,9 @@ func _handle_parsed_message(message_resource: Resource):
 		if not _received_initial_subscription:
 			_received_initial_subscription = true
 			self.database_initialized.emit()
-		var sub : SpacetimeDBSubscription= pending_subscriptions.get(message.query_id.id)
+		var sub : SpacetimeDBSubscription= _pending_subscriptions.get(message.query_id.id)
 		sub.applied.emit()
-		pending_subscriptions.erase(sub.query_id)
+		_pending_subscriptions.erase(sub.query_id)
 		current_subscriptions.set(sub.query_id, sub)
 		return
 
@@ -302,10 +303,10 @@ func _handle_parsed_message(message_resource: Resource):
 
 	elif message_resource is SubscriptionErrorMessage:
 		var message : SubscriptionErrorMessage = message_resource
-		var sub : SpacetimeDBSubscription= pending_subscriptions.get(message.query_id.id)
+		var sub : SpacetimeDBSubscription= _pending_subscriptions.get(message.query_id.id)
 		if sub:
 			sub.end.emit()
-			pending_subscriptions.erase(sub.query_id)
+			_pending_subscriptions.erase(sub.query_id)
 			sub.queue_free()
 		printerr("SpacetimeDBClient: Received SubscriptionErrorMessage: %s", message.error_message)
 		return
@@ -317,8 +318,8 @@ func _handle_parsed_message(message_resource: Resource):
 	elif message_resource is OneOffQueryResponseMessage:
 		var message : OneOffQueryResponseMessage = message_resource
 		var callback: Callable
-		callback = pending_one_off_query_callbacks.get(message.request_id, Callable())
-		pending_one_off_query_callbacks.erase(message.request_id)
+		callback = _pending_one_off_query_callbacks.get(message.request_id, Callable())
+		_pending_one_off_query_callbacks.erase(message.request_id)
 		if callback.is_valid():
 			callback.call(message)
 		else:
@@ -328,37 +329,27 @@ func _handle_parsed_message(message_resource: Resource):
 
 	elif message_resource is ReducerResultMessage:
 		print_log("SpacetimeDBClient: Handle Reducer result message")
-		var req_id: int = message_resource.request_id
 		match message_resource.reducer_result.value:
 			ReducerOutcomeEnum.Options.ok:
 				var ok_payload: TransactionUpdateMessage = message_resource.reducer_result.get_ok()
 				if ok_payload:
-					ok_payload.reducer_request_id = req_id
-					ok_payload.reducer_status = _make_committed_status()
 					_handle_transaction_update(ok_payload)
+				print_log("SpacetimeDBClient: Reducer returned sucessfully with data: %s" % str(message_resource.reducer_result.get_ok()))
 			ReducerOutcomeEnum.Options.okEmpty:
-				var empty_tx: TransactionUpdateMessage = TransactionUpdateMessage.new()
-				empty_tx.reducer_request_id = req_id
-				empty_tx.reducer_status = _make_committed_status()
-				_handle_transaction_update(empty_tx)
+				print_log("SpacetimeDBClient: Reducer returned sucessfully without data")
 			ReducerOutcomeEnum.Options.err:
-				var err_data: PackedByteArray = message_resource.reducer_result.get_err()
-				var err_msg: String = err_data.get_string_from_utf16() if err_data != null else "Reducer failed"
-				print_log("SpacetimeDBClient: Reducer err (ReqID %d): %s" % [req_id, err_msg])
-				var failed_tx: TransactionUpdateMessage = TransactionUpdateMessage.new()
-				failed_tx.reducer_request_id = req_id
-				failed_tx.reducer_status = _make_failed_status(err_msg)
-				_handle_transaction_update(failed_tx)
+				if debug_mode:
+					printerr("SpacetimeDBClient: Reducer returned with error: ", message_resource.reducer_result.get_err())
 			ReducerOutcomeEnum.Options.internalError:
-				var internal_msg: String = message_resource.reducer_result.get_internal_error()
-				print_log("SpacetimeDBClient: Reducer internalError (ReqID %d): %s" % [req_id, internal_msg])
-				var failed_tx: TransactionUpdateMessage = TransactionUpdateMessage.new()
-				failed_tx.reducer_request_id = req_id
-				failed_tx.reducer_status = _make_failed_status(internal_msg)
-				_handle_transaction_update(failed_tx)
+				if debug_mode:
+					printerr("SpacetimeDBClient: Reducer returned with server internal error: ", message_resource.reducer_result.get_internal_error())
+		if _pending_reducer_call.has(message_resource.request_id):
+			var reducer_call := _pending_reducer_call[message_resource.request_id]
+			_pending_reducer_call.erase(message_resource.request_id)
+			reducer_call.response.emit(message_resource)
+		else:
+			printerr("SpacetimeDBClient: Reducer timed out before the response message arrived")
 		return
-
-
 	else:
 		print_log("SpacetimeDBClient: Received unhandled message resource type: " + message_resource.get_class())
 
@@ -466,7 +457,7 @@ func subscribe(queries: PackedStringArray) -> SpacetimeDBSubscription:
 			subscription._ended = true
 		else:
 			print_log("SpacetimeDBClient: Subscribe request sent successfully (BSATN), Query ID: %d" % query_id)
-			pending_subscriptions.set(query_id, subscription)
+			_pending_subscriptions.set(query_id, subscription)
 			# Add as child for signals
 			subscription.name = "Subscription"
 			add_child(subscription)
@@ -527,7 +518,7 @@ func one_off_query(query: String, callback: Callable = func(ctx: OneOffQueryResp
 		if err != OK:
 			printerr("SpacetimeDBClient: Error sending One-off query BSATN message: %s" % error_string(err))
 		else:
-			pending_one_off_query_callbacks.set(request_id, callback)
+			_pending_one_off_query_callbacks.set(request_id, callback)
 			print_log("SpacetimeDBClient: One-off query request sent successfully (BSATN), Query: %s" % query)
 
 	return OK
@@ -547,7 +538,6 @@ func call_reducer(reducer_name: String, args: Array = [], types: Array = []) -> 
 
 	var request_id := _next_request_id
 	_next_request_id += 1
-	_request_id_to_reducer_name[request_id] = reducer_name
 
 	var call_data := CallReducerMessage.new(reducer_name, args_bytes, request_id, 0)
 	var message_bytes := _serializer.serialize_client_message(
@@ -567,52 +557,12 @@ func call_reducer(reducer_name: String, args: Array = [], types: Array = []) -> 
 		if err != OK:
 			print("SpacetimeDBClient: Error sending CallReducer JSON message: ", err)
 			return SpacetimeDBReducerCall.fail(err)
-
-		return SpacetimeDBReducerCall.create(self, request_id, reducer_name)
+		var reducer_call = SpacetimeDBReducerCall.create(self, request_id)
+		_pending_reducer_call.set(request_id, reducer_call)
+		return reducer_call
 
 	print("SpacetimeDBClient: Internal error - WebSocket peer not available in connection.")
 	return SpacetimeDBReducerCall.fail(ERR_CONNECTION_ERROR)
-
-func wait_for_reducer_response(request_id_to_match: int, timeout_seconds: float = 10.0) -> TransactionUpdateMessage:
-	if request_id_to_match < 0:
-		return null
-	var reducer_name_to_match: String = _request_id_to_reducer_name.get(request_id_to_match, "")
-	var timer: SceneTreeTimer = get_tree().create_timer(timeout_seconds)
-	var did_timeout: bool = false
-	timer.timeout.connect(func() -> void: did_timeout = true, CONNECT_ONE_SHOT)
-	var result_container = [null]
-	var connection:Callable = (
-		func(update: TransactionUpdateMessage):
-			if _check_reducer_response(update, request_id_to_match, reducer_name_to_match):
-				if result_container[0] == null:
-					result_container[0] = update
-					)
-
-	transaction_update_received.connect(connection)
-	while result_container[0] == null and not did_timeout:
-		await get_tree().process_frame
-
-	transaction_update_received.disconnect(connection)
-
-	var signal_result = result_container[0]
-	_request_id_to_reducer_name.erase(request_id_to_match)
-	if signal_result == null:
-		printerr("SpacetimeDBClient: Timeout waiting for response for Req ID: %d" % request_id_to_match)
-		self.reducer_call_timeout.emit(request_id_to_match)
-		return null
-	else:
-		var tx_update: TransactionUpdateMessage = signal_result
-		print_log("SpacetimeDBClient: Received matching response for Req ID: %d" % request_id_to_match)
-		self.reducer_call_response.emit(tx_update)
-		return tx_update
-
-func _check_reducer_response(update: TransactionUpdateMessage, request_id_to_match: int, _reducer_name_to_match: String = "") -> bool:
-	if update == null:
-		return false
-	# In 2.0, reducer results are tagged with reducer_request_id by the addon when handling ReducerResultMessage.
-	if update.reducer_request_id >= 0 and update.reducer_request_id == request_id_to_match:
-		return true
-	return false
 
 func call_procedure():
 	pass

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
@@ -346,7 +346,7 @@ func _handle_parsed_message(message_resource: Resource):
 		if _pending_reducer_call.has(message_resource.request_id):
 			var reducer_call := _pending_reducer_call[message_resource.request_id]
 			_pending_reducer_call.erase(message_resource.request_id)
-			reducer_call.response.emit(message_resource)
+			reducer_call.on_response(message_resource)
 		else:
 			printerr("SpacetimeDBClient: Reducer timed out before the response message arrived")
 		return

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
@@ -523,8 +523,6 @@ func one_off_query(query: String, callback: Callable = func(ctx: OneOffQueryResp
 
 	return OK
 
-
-
 func call_reducer(reducer_name: String, args: Array = [], types: Array = []) -> SpacetimeDBReducerCall:
 	if not is_connected_db():
 		printerr("SpacetimeDBClient: Cannot call reducer, not connected.")

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_reducer_call.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_reducer_call.gd
@@ -18,7 +18,6 @@ static func create(
 	var reducer_call := SpacetimeDBReducerCall.new()
 	reducer_call._client = p_client
 	reducer_call.request_id = p_request_id
-	reducer_call.response.connect(reducer_call._on_response)
 	return reducer_call
 
 static func fail(error: Error) -> SpacetimeDBReducerCall:

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_reducer_call.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_reducer_call.gd
@@ -26,7 +26,7 @@ static func fail(error: Error) -> SpacetimeDBReducerCall:
 	reducer_call.error = error
 	return reducer_call
 
-func _on_response(_response: ReducerResultMessage) -> void:
+func on_response(_response: ReducerResultMessage) -> void:
 	match _response.reducer_result.value:
 		ReducerOutcomeEnum.Options.ok:
 			on_ok.emit(_response)
@@ -36,3 +36,4 @@ func _on_response(_response: ReducerResultMessage) -> void:
 			on_error.emit(_response.reducer_result.get_err())
 		ReducerOutcomeEnum.Options.internalError:
 			on_internal_error.emit(_response.reducer_result.get_internal_error())
+	response.emit(_response)

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_reducer_call.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_reducer_call.gd
@@ -2,20 +2,23 @@ class_name SpacetimeDBReducerCall extends Resource
 
 var request_id: int = -1
 var error: Error = OK
-var reducer_name: String = ""
 
 var _client: SpacetimeDBClient
+
+signal response(call_response: ReducerResultMessage)
+signal on_ok(call_response: ReducerResultMessage)
+signal on_ok_empty(call_response: ReducerResultMessage)
+signal on_error(err: String)
+signal on_internal_error(err: PackedByteArray)
 
 static func create(
 	p_client: SpacetimeDBClient,
 	p_request_id: int,
-	p_reducer_name: String
 ) -> SpacetimeDBReducerCall:
 	var reducer_call := SpacetimeDBReducerCall.new()
 	reducer_call._client = p_client
 	reducer_call.request_id = p_request_id
-	reducer_call.reducer_name = p_reducer_name
-
+	reducer_call.response.connect(reducer_call._on_response)
 	return reducer_call
 
 static func fail(error: Error) -> SpacetimeDBReducerCall:
@@ -23,8 +26,13 @@ static func fail(error: Error) -> SpacetimeDBReducerCall:
 	reducer_call.error = error
 	return reducer_call
 
-func wait_for_response(timeout_sec: float = 10) -> TransactionUpdateMessage:
-	if error:
-		return null
-
-	return await _client.wait_for_reducer_response(request_id, timeout_sec)
+func _on_response(_response: ReducerResultMessage) -> void:
+	match _response.reducer_result.value:
+		ReducerOutcomeEnum.Options.ok:
+			on_ok.emit(_response)
+		ReducerOutcomeEnum.Options.okEmpty:
+			on_ok_empty.emit(_response)
+		ReducerOutcomeEnum.Options.err:
+			on_error.emit(_response.reducer_result.get_err())
+		ReducerOutcomeEnum.Options.internalError:
+			on_internal_error.emit(_response.reducer_result.get_internal_error())

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_reducer_call.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_reducer_call.gd
@@ -9,7 +9,7 @@ signal response(call_response: ReducerResultMessage)
 signal on_ok(call_response: ReducerResultMessage)
 signal on_ok_empty(call_response: ReducerResultMessage)
 signal on_error(err: String)
-signal on_internal_error(err: PackedByteArray)
+signal on_internal_error(err: String)
 
 static func create(
 	p_client: SpacetimeDBClient,

--- a/godot-client/addons/SpacetimeDB/core_types/WS protocol/reducer_outcome_enum.gd
+++ b/godot-client/addons/SpacetimeDB/core_types/WS protocol/reducer_outcome_enum.gd
@@ -30,10 +30,19 @@ static func parse_enum_name(i: int) -> String:
 			return &'Unknown'
 
 func get_ok() -> TransactionUpdateMessage:
+	if value != 0:
+		printerr("ReducerOutcomeEnum Value is not 'ok' but get_err() got called")
+		return null
 	return data
 
-func get_err() -> PackedByteArray:
-	return data
+func get_err() -> String:
+	if value != 2:
+		printerr("ReducerOutcomeEnum Value is not 'err' but get_err() got called")
+		return ""
+	var raw_err : PackedByteArray = data as PackedByteArray
+	### for some reason the frist 3 are ")  " and thus get removed
+	### TODO: Review after V10 schema codegen changes. it should be the Reducer return specified in the schema
+	return raw_err.slice(4).get_string_from_utf8()
 
 func get_internal_error() -> String:
 	return data

--- a/godot-client/addons/SpacetimeDB/core_types/server_message/transaction_update.gd
+++ b/godot-client/addons/SpacetimeDB/core_types/server_message/transaction_update.gd
@@ -2,11 +2,3 @@
 class_name TransactionUpdateMessage extends Resource
 
 @export var query_sets: Array[DatabaseUpdateData]
-
-## When set (>= 0), this update is a reducer result for that request_id. Set by the addon when handling ReducerResultMessage.
-@export var reducer_request_id: int = -1
-## When set, indicates reducer outcome (COMMITTED, FAILED, etc.). Set by the addon when handling ReducerResultMessage.
-@export var reducer_status: UpdateStatusData = null
-
-#func _init() -> void:
-	#set_meta("bsatn_type_query_sets", &"DatabaseUpdateData")

--- a/godot-client/example_code/integration_tests.gd
+++ b/godot-client/example_code/integration_tests.gd
@@ -59,18 +59,23 @@ func _on_spacetimedb_database_init() -> void:
 
 
 func _on_button_pressed() -> void:
-	SpacetimeDB.Main.reducers.start_integration_tests(func(update:TransactionUpdateMessage)->void:
-		print("Reducer callback test. update resource: %s" %update)
-		)
+	var call1 : SpacetimeDBReducerCall = SpacetimeDB.Main.reducers.start_integration_tests()
+	call1.on_ok.connect(func(update:ReducerResultMessage) -> void: print("Reducer call1 returned Ok with %s" % update))
+	var time := Time.get_ticks_usec()
+	await call1.response
+	prints("call1 response took:",Time.get_ticks_usec() - time, "usec")
 	var main_test_type: MainTestType = MainTestType.create("hello world",8,MainTestNestedEnum.create_ok_empty())
 	var main_test_type_Option: Option = Option.some(main_test_type)
 	var u128 := [8]
 	u128.resize(16)
 	var main_test_datatypes: MainTestTableDatatypes = MainTestTableDatatypes.create(64,8,16,32,PackedByteArray(u128),32.0,64.0,8,16,32,64,"hello world",["hello world","hello world2"],[8,8],Option.some("hello world"),Option.some(64),SpacetimeDB.Main.Types.TestEnum.A,[SpacetimeDB.Main.Types.TestEnum.A],Option.some(SpacetimeDB.Main.Types.TestEnum.A),main_test_type,[main_test_type],main_test_type_Option )
 
-	SpacetimeDB.Main.reducers.reducer_test_parameters(main_test_datatypes, 32,64,"hello world",SpacetimeDB.Main.Types.TestEnum.A,MainTestNestedEnum.create_ok_empty(),[32,32])
-
-
+	var call2 : SpacetimeDBReducerCall = SpacetimeDB.Main.reducers.reducer_test_parameters(main_test_datatypes, 32,64,"hello world",SpacetimeDB.Main.Types.TestEnum.A,MainTestNestedEnum.create_ok_empty(),[32,32])
+	call2.on_ok.connect(func(update: ReducerResultMessage) -> void: print("Reducer call2 returned Ok with %s" % update))
+	call2.on_error.connect(func(err: String) -> void: print("Reducer call2 returned err with %s" % err))
+	var time2 := Time.get_ticks_usec()
+	await call2.response
+	prints("call2 response took:",Time.get_ticks_usec() - time2, "usec")
 
 func _on_button_2_pressed() -> void:
 	SpacetimeDB.Main.reducers.clear_integration_tests() # Replace with function body.

--- a/godot-client/example_code/player.gd
+++ b/godot-client/example_code/player.gd
@@ -32,16 +32,17 @@ func test_struct():
 	option_inner.set_some(test_damage)
 	test_one.test_inner = option_inner
 
-	var res = await SpacetimeDB.Main.reducers.test_struct(test_one, func(_t):
-		print("Result:", _t)
-	)
+	var res := SpacetimeDB.Main.reducers.test_struct(test_one)
+	res.response.connect(func(_t: ReducerResultMessage) -> void:
+		print("Result:", _t))
+	await res.response
 
-func test_option_vec(text):
-	var opt = Option.new()
+func test_option_vec(text) -> void:
+	var opt := Option.new()
 	opt.set_some(text)
 	SpacetimeDB.Main.reducers.test_option_vec(opt)
 
-func test_option_single(text):
+func test_option_single(text) -> void:
 	var opt = Option.new()
 	opt.set_some(text)
 	SpacetimeDB.Main.reducers.test_option_single(opt)
@@ -55,7 +56,7 @@ func _input(event: InputEvent) -> void:
 		test_option_vec(["Hello","World"])
 		test_option_single("Welcome")
 
-func _initialize_player_on_insert(user_data: MainUserData):
+func _initialize_player_on_insert(user_data: MainUserData) -> void:
 	#Need to receive only THIS entity/table updates
 	if get_meta("id") != user_data.identity:
 		return
@@ -66,7 +67,7 @@ func _initialize_player_on_insert(user_data: MainUserData):
 	remote_input = user_data.direction
 	remote_speed = user_data.player_speed
 
-func _update_player_on_row_update(prev_value: MainUserData, user_data: MainUserData):
+func _update_player_on_row_update(_prev_value: MainUserData, user_data: MainUserData) -> void:
 	#Need to receive only THIS entity/table updates
 	if get_meta("id") != user_data.identity:
 		return

--- a/godot-client/project.godot
+++ b/godot-client/project.godot
@@ -13,7 +13,7 @@ config_version=5
 config/name="Unofficial SpacetimeDB SDK"
 config/tags=PackedStringArray("git")
 run/main_scene="uid://bbffb4bvr3yin"
-config/features=PackedStringArray("4.6", "Mobile")
+config/features=PackedStringArray("4.7", "Mobile")
 config/icon="res://icon.svg"
 
 [autoload]

--- a/godot-client/spacetime_bindings/schema/module_main_client.gd
+++ b/godot-client/spacetime_bindings/schema/module_main_client.gd
@@ -17,6 +17,35 @@ const Damage = Types.Damage
 const User = Types.User
 const UserData = Types.UserData
 
+
+## example usage:
+## [codeblock]
+## # Reducer call returns a call object that the response will use to send out it's callback signals
+## var call : SpacetimeDBReducerCall = SpacetimeDB.Main.reducers.example_reducer()
+##
+## # checking if the reducer call was send out successfully
+## if call.error:
+##     # handle reducer call error
+##     pass
+##
+## # general callback signal
+## call.response.connect(func(update:ReducerResultMessage) -> void: pass)
+##
+## # reducer successfully ran and returned with data (general subscription data)
+## call.on_ok.connect(func(update:ReducerResultMessage) -> void: pass)
+##
+## # reducer successfully ran and returned without data
+## call.on_ok_empty.connect(func(update:ReducerResultMessage) -> void: pass)
+##
+## # reducer failed to run and returned with the error string
+## call.on_error.conect(func(err: String) -> void: pass)
+##
+## # reducer failed with internal error. not expected to be ever called.
+## call.on_internal_error.conect(func(err: String) -> void: pass)
+##
+## waiting for the reducer response
+## await call1.response
+## [/codeblock]
 var reducers: MainModuleReducers
 var db: MainModuleDb
 

--- a/godot-client/spacetime_bindings/schema/module_main_reducers.gd
+++ b/godot-client/spacetime_bindings/schema/module_main_reducers.gd
@@ -52,3 +52,4 @@ func test_scheduled_reducer(row: MainTestScheduledTable) -> SpacetimeDBReducerCa
 ## 0. message: MainMessage [br]
 func test_struct(message: MainMessage) -> SpacetimeDBReducerCall:
 	return _client.call_reducer('test_struct', [message], [&'MainMessage'])
+

--- a/godot-client/spacetime_bindings/schema/module_main_reducers.gd
+++ b/godot-client/spacetime_bindings/schema/module_main_reducers.gd
@@ -7,38 +7,17 @@ var _client: SpacetimeDBClient
 func _init(p_client: SpacetimeDBClient) -> void:
 	_client = p_client
 
-func change_color_random(cb: Callable = func(_t: TransactionUpdateMessage) -> void: pass) -> Error:
-	var __handle__ : SpacetimeDBReducerCall = _client.call_reducer('change_color_random', [], [])
-	if __handle__.error: return __handle__.error
-	var __result__: TransactionUpdateMessage = await __handle__.wait_for_response()
-	if cb.is_valid():
-		cb.call(__result__)
-	else:
-		return ERR_METHOD_NOT_FOUND
-	return OK
+func change_color_random() -> SpacetimeDBReducerCall:
+	return _client.call_reducer('change_color_random', [], [])
 
 
-func clear_integration_tests(cb: Callable = func(_t: TransactionUpdateMessage) -> void: pass) -> Error:
-	var __handle__ : SpacetimeDBReducerCall = _client.call_reducer('clear_integration_tests', [], [])
-	if __handle__.error: return __handle__.error
-	var __result__: TransactionUpdateMessage = await __handle__.wait_for_response()
-	if cb.is_valid():
-		cb.call(__result__)
-	else:
-		return ERR_METHOD_NOT_FOUND
-	return OK
+func clear_integration_tests() -> SpacetimeDBReducerCall:
+	return _client.call_reducer('clear_integration_tests', [], [])
 
 ## 0. new_input: Vector2 [br]
 ## 1. global_position: Vector3 [br]
-func move_user(new_input: Vector2, global_position: Vector3, cb: Callable = func(_t: TransactionUpdateMessage) -> void: pass) -> Error:
-	var __handle__ : SpacetimeDBReducerCall = _client.call_reducer('move_user', [new_input, global_position], [&'vector2[f32,f32]', &'vector3[f32,f32,f32]'])
-	if __handle__.error: return __handle__.error
-	var __result__: TransactionUpdateMessage = await __handle__.wait_for_response()
-	if cb.is_valid():
-		cb.call(__result__)
-	else:
-		return ERR_METHOD_NOT_FOUND
-	return OK
+func move_user(new_input: Vector2, global_position: Vector3) -> SpacetimeDBReducerCall:
+	return _client.call_reducer('move_user', [new_input, global_position], [&'vector2[f32,f32]', &'vector3[f32,f32,f32]'])
 
 ## 0. datatypes: MainTestTableDatatypes [br]
 ## 1. t_u32: int [br]
@@ -47,78 +26,29 @@ func move_user(new_input: Vector2, global_position: Vector3, cb: Callable = func
 ## 4. test_enum: MainModuleClient.Types.TestEnum [br]
 ## 5. test_nested_enum: MainTestNestedEnum [br]
 ## 6. t_vec_u32: Array of int [br]
-func reducer_test_parameters(datatypes: MainTestTableDatatypes, t_u32: int, t_u64: int, t_string: String, test_enum: MainModuleClient.Types.TestEnum, test_nested_enum: MainTestNestedEnum, t_vec_u32: Array[int], cb: Callable = func(_t: TransactionUpdateMessage) -> void: pass) -> Error:
-	var __handle__ : SpacetimeDBReducerCall = _client.call_reducer('reducer_test_parameters', [datatypes, t_u32, t_u64, t_string, test_enum, test_nested_enum, t_vec_u32], [&'MainTestTableDatatypes', &'u32', &'u64', &'string', &'u8', &'MainTestNestedEnum', &'u32'])
-	if __handle__.error: return __handle__.error
-	var __result__: TransactionUpdateMessage = await __handle__.wait_for_response()
-	if cb.is_valid():
-		cb.call(__result__)
-	else:
-		return ERR_METHOD_NOT_FOUND
-	return OK
+func reducer_test_parameters(datatypes: MainTestTableDatatypes, t_u32: int, t_u64: int, t_string: String, test_enum: MainModuleClient.Types.TestEnum, test_nested_enum: MainTestNestedEnum, t_vec_u32: Array[int]) -> SpacetimeDBReducerCall:
+	return _client.call_reducer('reducer_test_parameters', [datatypes, t_u32, t_u64, t_string, test_enum, test_nested_enum, t_vec_u32], [&'MainTestTableDatatypes', &'u32', &'u64', &'string', &'u8', &'MainTestNestedEnum', &'u32'])
 
 ## 0. bytes: Array of int [br]
-func save_my_bytes(bytes: Array[int], cb: Callable = func(_t: TransactionUpdateMessage) -> void: pass) -> Error:
-	var __handle__ : SpacetimeDBReducerCall = _client.call_reducer('save_my_bytes', [bytes], [&'u8'])
-	if __handle__.error: return __handle__.error
-	var __result__: TransactionUpdateMessage = await __handle__.wait_for_response()
-	if cb.is_valid():
-		cb.call(__result__)
-	else:
-		return ERR_METHOD_NOT_FOUND
-	return OK
+func save_my_bytes(bytes: Array[int]) -> SpacetimeDBReducerCall:
+	return _client.call_reducer('save_my_bytes', [bytes], [&'u8'])
 
 
-func start_integration_tests(cb: Callable = func(_t: TransactionUpdateMessage) -> void: pass) -> Error:
-	var __handle__ : SpacetimeDBReducerCall = _client.call_reducer('start_integration_tests', [], [])
-	if __handle__.error: return __handle__.error
-	var __result__: TransactionUpdateMessage = await __handle__.wait_for_response()
-	if cb.is_valid():
-		cb.call(__result__)
-	else:
-		return ERR_METHOD_NOT_FOUND
-	return OK
+func start_integration_tests() -> SpacetimeDBReducerCall:
+	return _client.call_reducer('start_integration_tests', [], [])
 
 ## 0. option: Option of String [br]
-func test_option_single(option: Option, cb: Callable = func(_t: TransactionUpdateMessage) -> void: pass) -> Error:
-	var __handle__ : SpacetimeDBReducerCall = _client.call_reducer('test_option_single', [option], [&'string'])
-	if __handle__.error: return __handle__.error
-	var __result__: TransactionUpdateMessage = await __handle__.wait_for_response()
-	if cb.is_valid():
-		cb.call(__result__)
-	else:
-		return ERR_METHOD_NOT_FOUND
-	return OK
+func test_option_single(option: Option) -> SpacetimeDBReducerCall:
+	return _client.call_reducer('test_option_single', [option], [&'string'])
 
 ## 0. option: Option of Array of String [br]
-func test_option_vec(option: Option, cb: Callable = func(_t: TransactionUpdateMessage) -> void: pass) -> Error:
-	var __handle__ : SpacetimeDBReducerCall = _client.call_reducer('test_option_vec', [option], [&'vec_string'])
-	if __handle__.error: return __handle__.error
-	var __result__: TransactionUpdateMessage = await __handle__.wait_for_response()
-	if cb.is_valid():
-		cb.call(__result__)
-	else:
-		return ERR_METHOD_NOT_FOUND
-	return OK
+func test_option_vec(option: Option) -> SpacetimeDBReducerCall:
+	return _client.call_reducer('test_option_vec', [option], [&'vec_string'])
 
 ## 0. row: MainTestScheduledTable [br]
-func test_scheduled_reducer(row: MainTestScheduledTable, cb: Callable = func(_t: TransactionUpdateMessage) -> void: pass) -> Error:
-	var __handle__ : SpacetimeDBReducerCall = _client.call_reducer('test_scheduled_reducer', [row], [&'MainTestScheduledTable'])
-	if __handle__.error: return __handle__.error
-	var __result__: TransactionUpdateMessage = await __handle__.wait_for_response()
-	if cb.is_valid():
-		cb.call(__result__)
-	else:
-		return ERR_METHOD_NOT_FOUND
-	return OK
+func test_scheduled_reducer(row: MainTestScheduledTable) -> SpacetimeDBReducerCall:
+	return _client.call_reducer('test_scheduled_reducer', [row], [&'MainTestScheduledTable'])
 
 ## 0. message: MainMessage [br]
-func test_struct(message: MainMessage, cb: Callable = func(_t: TransactionUpdateMessage) -> void: pass) -> Error:
-	var __handle__ : SpacetimeDBReducerCall = _client.call_reducer('test_struct', [message], [&'MainMessage'])
-	if __handle__.error: return __handle__.error
-	var __result__: TransactionUpdateMessage = await __handle__.wait_for_response()
-	if cb.is_valid():
-		cb.call(__result__)
-	else:
-		return ERR_METHOD_NOT_FOUND
-	return OK
+func test_struct(message: MainMessage) -> SpacetimeDBReducerCall:
+	return _client.call_reducer('test_struct', [message], [&'MainMessage'])

--- a/test-server-module/Cargo.toml
+++ b/test-server-module/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = { version = "2.0.2", features = ["unstable"] }
+spacetimedb = { version = "2.0.3", features = ["unstable"] }
 log = "0.4"
 
 #[build-dependencies]


### PR DESCRIPTION
changelog:
- overhaul on how reducer calls work
- update of the docs for reducers 
- update to the readme

new api:

```gdscript
# Reducer call returns a call object that the response will use to send out it's callback signals
var call : SpacetimeDBReducerCall = SpacetimeDB.Main.reducers.example_reducer()

# checking if the reducer call was send out successfully
if call.error:
    # handle reducer call error
    pass

# general callback signal
call.response.connect(func(update:ReducerResultMessage) -> void: pass)

# reducer successfully ran and returned with data (general subscription data)
call.on_ok.connect(func(update:ReducerResultMessage) -> void: pass)

# reducer successfully ran and returned without data
call.on_ok_empty.connect(func(update:ReducerResultMessage) -> void: pass)

# reducer failed to run and returned with the error string
call.on_error.conect(func(err: String) -> void: pass)

# reducer failed with internal error. not expected to be ever called.
call.on_internal_error.conect(func(err: String) -> void: pass)

# waiting for the reducer response
await call1.response
```