### PR TITLE
Add procedure call support implementation

### DIFF
--- a/godot-client/addons/SpacetimeDB/core/bsatn_deserializer.gd
+++ b/godot-client/addons/SpacetimeDB/core/bsatn_deserializer.gd
@@ -1003,6 +1003,31 @@ func _read_subscription_error_message(spb: StreamPeerBuffer) -> SubscriptionErro
 	resource.error_message = read_string_with_u32_len(spb)
 	return null if has_error() else resource
 
+func _read_procedure_result_message(spb: StreamPeerBuffer) -> ProcedureResultMessage:
+	# v2 ProcedureResult wire format (fields in declaration order):
+	#   status: ProcedureStatus (tag u8 + payload)
+	#   timestamp: i64 nanoseconds (8 bytes)
+	#   total_host_execution_duration: i64 microseconds (8 bytes)
+	#   request_id: u32 (last)
+	var resource := ProcedureResultMessage.new()
+	var tag := read_u8(spb); if has_error(): return null
+	match tag:
+		0:  # Returned(Bytes) — length-prefixed return value bytes
+			var byte_count := read_u32_le(spb); if has_error(): return null
+			if byte_count > 0:
+				spb.seek(spb.get_position() + byte_count)
+			resource.success = true
+		1:  # InternalError(String)
+			resource.error_msg = read_string_with_u32_len(spb); if has_error(): return null
+			resource.success = false
+		_:
+			_set_error("Unknown ProcedureStatus tag: %d" % tag)
+			return null
+	spb.seek(spb.get_position() + 16)  # skip timestamp (i64) + duration (i64)
+	if has_error(): return null
+	resource.request_id = read_u32_le(spb); if has_error(): return null
+	return resource
+
 func _read_reducer_result_message(spb: StreamPeerBuffer)-> ReducerResultMessage:
 	var resource := ReducerResultMessage.new()
 
@@ -1256,6 +1281,10 @@ func _parse_message_from_stream(spb: StreamPeerBuffer) -> Resource:
 
 	elif msg_type == SpacetimeDBServerMessage.REDUCER_RESULT:
 		result_resource = _read_reducer_result_message(spb)
+		if has_error(): return null
+
+	elif msg_type == SpacetimeDBServerMessage.PROCEDURE_RESULT:
+		result_resource = _read_procedure_result_message(spb)
 		if has_error(): return null
 
 	# --- Generic handling for types parsed via _populate_resource_from_bytes ---

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
@@ -61,6 +61,7 @@ signal row_transactions_completed(table_name: String)
 signal reducer_call_response(response: Resource) # TODO: Define response resource
 signal reducer_call_timeout(request_id: int) # TODO: Implement timeout logic
 signal transaction_update_received(update: TransactionUpdateMessage)
+signal procedure_completed(request_id: int, success: bool, error_msg: String)
 
 func _ready():
 	if auto_connect:
@@ -327,6 +328,15 @@ func _handle_parsed_message(message_resource: Resource):
 		print_log("SpacetimeDBClient: Received message resource type: OneOffQueryResponseMessage")
 		return
 
+	elif message_resource is ProcedureResultMessage:
+		var msg: ProcedureResultMessage = message_resource
+		if msg.success:
+			print_log("SpacetimeDBClient: Procedure request_id=%d succeeded." % msg.request_id)
+		else:
+			printerr("SpacetimeDBClient: Procedure request_id=%d failed: %s" % [msg.request_id, msg.error_msg])
+		procedure_completed.emit(msg.request_id, msg.success, msg.error_msg)
+		return
+
 	elif message_resource is ReducerResultMessage:
 		print_log("SpacetimeDBClient: Handle Reducer result message")
 		match message_resource.reducer_result.value:
@@ -562,5 +572,31 @@ func call_reducer(reducer_name: String, args: Array = [], types: Array = []) -> 
 	print("SpacetimeDBClient: Internal error - WebSocket peer not available in connection.")
 	return SpacetimeDBReducerCall.fail(ERR_CONNECTION_ERROR)
 
-func call_procedure():
-	pass
+func call_procedure(procedure_name: String, args: Array = [], types: Array = []) -> SpacetimeDBProcedureCall:
+	if not is_connected_db():
+		printerr("SpacetimeDBClient: Cannot call procedure, not connected.")
+		return SpacetimeDBProcedureCall.fail(ERR_CONNECTION_ERROR)
+
+	var args_bytes := _serializer._serialize_arguments(args, types)
+	if _serializer.has_error():
+		printerr("SpacetimeDBClient: Failed to serialize args for %s: %s" % [procedure_name, _serializer.get_last_error()])
+		return SpacetimeDBProcedureCall.fail(ERR_PARSE_ERROR)
+
+	var request_id := _next_request_id
+	_next_request_id += 1
+
+	var call_data := CallProcedureMessage.new(procedure_name, args_bytes, request_id, 0)
+	var message_bytes := _serializer.serialize_client_message(SpacetimeDBClientMessage.CALL_PROCEDURE, call_data)
+	if _serializer.has_error():
+		printerr("SpacetimeDBClient: Failed to serialize CallProcedure message: %s" % _serializer.get_last_error())
+		return SpacetimeDBProcedureCall.fail(ERR_PARSE_ERROR)
+
+	if _connection and _connection._websocket:
+		var err := _connection.send_bytes(message_bytes)
+		if err != OK:
+			printerr("SpacetimeDBClient: Error sending CallProcedure message: ", err)
+			return SpacetimeDBProcedureCall.fail(err)
+		return SpacetimeDBProcedureCall.create(self, request_id, procedure_name)
+
+	printerr("SpacetimeDBClient: Internal error - WebSocket peer not available in connection.")
+	return SpacetimeDBProcedureCall.fail(ERR_CONNECTION_ERROR)

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
@@ -60,6 +60,7 @@ signal row_transactions_completed(table_name: String)
 
 signal reducer_call_response(response: Resource) # TODO: Define response resource
 signal reducer_call_timeout(request_id: int) # TODO: Implement timeout logic
+signal procedure_call_timeout(request_id: int)
 signal transaction_update_received(update: TransactionUpdateMessage)
 signal procedure_completed(request_id: int, success: bool, error_msg: String)
 
@@ -600,3 +601,29 @@ func call_procedure(procedure_name: String, args: Array = [], types: Array = [])
 
 	printerr("SpacetimeDBClient: Internal error - WebSocket peer not available in connection.")
 	return SpacetimeDBProcedureCall.fail(ERR_CONNECTION_ERROR)
+
+func wait_for_procedure_response(request_id_to_match: int, timeout_seconds: float = 10.0) -> ProcedureResultMessage:
+	if request_id_to_match < 0:
+		return null
+	var timer: SceneTreeTimer = get_tree().create_timer(timeout_seconds)
+	var did_timeout: bool = false
+	timer.timeout.connect(func() -> void: did_timeout = true, CONNECT_ONE_SHOT)
+	var result_container = [null]
+	var connection: Callable = (
+		func(req_id: int, success: bool, error_msg: String):
+			if req_id == request_id_to_match:
+				var msg := ProcedureResultMessage.new()
+				msg.request_id = req_id
+				msg.success = success
+				msg.error_msg = error_msg
+				result_container[0] = msg
+	)
+	procedure_completed.connect(connection)
+	while result_container[0] == null and not did_timeout:
+		await get_tree().process_frame
+	procedure_completed.disconnect(connection)
+	if result_container[0] == null:
+		printerr("SpacetimeDBClient: Timeout waiting for procedure response for Req ID: %d" % request_id_to_match)
+		procedure_call_timeout.emit(request_id_to_match)
+		return null
+	return result_container[0]

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_procedure_call.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_procedure_call.gd
@@ -14,7 +14,7 @@ static func create(
 	var procedure_call := SpacetimeDBProcedureCall.new()
 	procedure_call._client = p_client
 	procedure_call.request_id = p_request_id
-	procedure_call.reducer_name = p_procedure_name
+	procedure_call.procedure_name = p_procedure_name
 
 	return procedure_call
 

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_procedure_call.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_procedure_call.gd
@@ -23,7 +23,7 @@ static func fail(error: Error) -> SpacetimeDBProcedureCall:
 	procedure_call.error = error
 	return procedure_call
 
-func wait_for_response(timeout_sec: float = 10) -> TransactionUpdateMessage:
+func wait_for_response(timeout_sec: float = 10) -> ProcedureResultMessage:
 	if error:
 		return null
 

--- a/godot-client/addons/SpacetimeDB/core_types/server_message/procedure_result.gd
+++ b/godot-client/addons/SpacetimeDB/core_types/server_message/procedure_result.gd
@@ -1,0 +1,6 @@
+@tool
+class_name ProcedureResultMessage extends Resource
+
+@export var request_id: int
+@export var success: bool = true
+@export var error_msg: String = ""

--- a/godot-client/addons/SpacetimeDB/core_types/server_message/procedure_result.gd.uid
+++ b/godot-client/addons/SpacetimeDB/core_types/server_message/procedure_result.gd.uid
@@ -1,0 +1,1 @@
+uid://dbmsmvhre8gaf

--- a/godot-client/addons/SpacetimeDB/core_types/server_message/spacetimedb_server_message.gd
+++ b/godot-client/addons/SpacetimeDB/core_types/server_message/spacetimedb_server_message.gd
@@ -19,6 +19,6 @@ static func get_resource_path(msg_type: int) -> String:
 		TRANSACTION_UPDATE:        return "res://addons/SpacetimeDB/core_types/server_message/transaction_update.gd"
 		ONE_OFF_QUERY_RESPONSE:    return "res://addons/SpacetimeDB/core_types/server_message/one_off_query_response.gd" # IMPLEMENT READER
 		REDUCER_RESULT:             return "res://addons/SpacetimeDB/core_types/server_message/reducer_result.gd"
-		#PROCEDURE_RESULT
+		PROCEDURE_RESULT:           return "res://addons/SpacetimeDB/core_types/server_message/procedure_result.gd"
 		_:
 			return ""


### PR DESCRIPTION
I got procedures to succeed and print Error message to client on failure.

The func SpacetimeDB.Pb.call_procedure requires args as input, which is not optimal the codegen could probably do this.

I used the signal SpacetimeDB.Pb.procedure_completed(request_id: int, success: bool, error_msg: String) like so:
```
func _ready() -> void:
	SpacetimeDB.Pb.procedure_completed.connect(_on_procedure_completed)
	var call = SpacetimeDB.Pb.call_procedure("verify_steam_ticket", ["123token123"], [&"string"])
	_steam_procedure_request_id = call.request_id

func _on_procedure_completed(request_id: int, success: bool, error_msg: String) -> void:
	if request_id != _steam_procedure_request_id:
		return
```