### PR TITLE
fix(codegen): initialize table_names only when key is absent

### DIFF
--- a/godot-client/addons/SpacetimeDB/codegen/schema_parser.gd
+++ b/godot-client/addons/SpacetimeDB/codegen/schema_parser.gd
@@ -226,7 +226,7 @@ static func parse_schema(p_schema: Dictionary, module_name: String) -> Spacetime
 			"type_idx": target_type_idx
 		}
 
-		if not target_type_def.has("source_name"):
+		if not target_type_def.has("table_names"):
 			target_type_def.table_names = []
 		target_type_def.table_names.append(table_name_str)
 		target_type_def.table_name = table_name_str


### PR DESCRIPTION
Use has("table_names") instead of has("source_name") so multiple table aliases correctly accumulate on the type definition.

This was causing types with multiple accessors to only reference one and triggering the error: `LocalDatabase: Received update for unknown table `for the unreferenced accessors.