### PR TITLE
Stdb v2 csharp compatibility

### DIFF
--- a/godot-client/addons/SpacetimeDB/codegen/codegen.gd
+++ b/godot-client/addons/SpacetimeDB/codegen/codegen.gd
@@ -622,9 +622,10 @@ func _generate_reducers_gdscript(
 
 		content += "\n".join(description_comment) + "\n"
 		var reducer_name: String = reducer_def.get("name", "")
+		var reducer_source_name: String = reducer_def.get("source_name", reducer_name)
 		content += "func %s(%s) -> SpacetimeDBReducerCall:\n" % [reducer_name, params_str] + \
 			"\treturn _client.call_reducer('%s', [%s], [%s])\n\n" % [
-				reducer_name,
+				reducer_source_name,
 				param_names_str,
 				param_bsatn_types_str,
 			]
@@ -674,9 +675,10 @@ func _generate_procedures_gdscript(
 
 		content += "\n".join(description_comment) + "\n"
 		var procedure_name: String = procedure_def.get("name", "")
+		var procedure_source_name: String = procedure_def.get("source_name", procedure_name)
 		content += "func %s(%s) -> SpacetimeDBProcedureCall:\n" % [procedure_name, params_str] + \
 			"\treturn _client.call_procedure('%s', [%s], [%s], '%s')\n\n" % [
-				procedure_name,
+				procedure_source_name,
 				param_names_str,
 				param_bsatn_types_str,
 				return_name,

--- a/godot-client/addons/SpacetimeDB/codegen/codegen.gd
+++ b/godot-client/addons/SpacetimeDB/codegen/codegen.gd
@@ -269,7 +269,7 @@ func _generate_table_unique_index_gdscript(
 		"class_name %s extends _ModuleTableUniqueIndex\n\n" % class_name_text + \
 		"var _cache: Dictionary[%s, %s] = {}\n\n" % [field_type, type_name] + \
 		"func _init() -> void:\n" + \
-		"\tset_meta(\"table_name\", \"%s\")\n" % table_name.trim_prefix(schema.module.to_lower() + "_") + \
+		"\tset_meta(\"table_name\", \"%s\")\n" % table_name.to_snake_case().trim_prefix(schema.module.to_snake_case() + "_") + \
 		"\tset_meta(\"field_name\", \"%s\")\n\n" % field_name + \
 		"static func create(p_local_db: LocalDatabase) -> %s:\n" % class_name_text + \
 		"\tvar index: %s = %s.new()\n" % [class_name_text, class_name_text] + \
@@ -305,7 +305,7 @@ func _generate_table_gdscript(
 	for field_name in unique_index_classes:
 		content += "var %s: %s\n" % [field_name, unique_index_classes[field_name]]
 	content += "\nfunc _init() -> void:\n" + \
-		"\tset_meta(\"table_name\", \"%s\")\n" % table_name.trim_prefix(schema.module.to_lower() + "_") + \
+		"\tset_meta(\"table_name\", \"%s\")\n" % table_name.to_snake_case().trim_prefix(schema.module.to_snake_case() + "_") + \
 		"\tset_meta(\"is_event\", \"%s\")\n" % table_def.get("is_event") + \
 		"\tset_meta(\"type\", \"%s\")\n" % type_name
 

--- a/godot-client/addons/SpacetimeDB/codegen/schema_parser.gd
+++ b/godot-client/addons/SpacetimeDB/codegen/schema_parser.gd
@@ -585,12 +585,13 @@ static func _parse_callables(
 		if info.get("visibility", {}).has("Private"):
 			continue
 
-		var name: String= info.get("source_name", "").to_snake_case()
+		var source_name: String = info.get("source_name", "")
+		var name: String = source_name.to_snake_case()
 		if name.is_empty():
 			SpacetimePlugin.print_err("Callable found with no name: %s" % [info])
 			continue
 
-		var callable_data: Dictionary = {"name": name}
+		var callable_data: Dictionary = {"name": name, "source_name": source_name}
 		callable_data["params"] = _parse_named_elements(
 			info.get("params", {}).get("elements", []),
 			schema_types,

--- a/godot-client/addons/SpacetimeDB/core/local_database.gd
+++ b/godot-client/addons/SpacetimeDB/core/local_database.gd
@@ -174,7 +174,7 @@ func emit_db_callbacks(changes:Array[Dictionary]):
 			row_transactions_completed.emit(table_name)
 
 func apply_table_update(table_update: TableUpdateData) -> Dictionary[String,Array]:
-	var table_name_original: StringName = StringName(table_update.table_name)
+	var table_name_original: StringName = StringName(table_update.table_name.to_snake_case())
 
 	if not _tables.has(table_name_original):
 		printerr("LocalDatabase: Received update for unknown table: ", table_name_original)

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
@@ -61,6 +61,7 @@ signal row_transactions_completed(table_name: String)
 
 signal reducer_call_response(response: Resource) # TODO: Define response resource
 signal reducer_call_timeout(request_id: int) # TODO: Implement timeout logic
+signal procedure_call_response(response: ProcedureResultMessage)
 signal transaction_update_received(update: TransactionUpdateMessage)
 
 func _ready():
@@ -354,7 +355,7 @@ func _handle_parsed_message(message_resource: Resource):
 			var reducer_call := _pending_reducer_call[message_resource.request_id]
 			_pending_reducer_call.erase(message_resource.request_id)
 			reducer_call.on_response(message_resource)
-			print("Reducer call on_response called")
+			reducer_call_response.emit(message_resource)
 		else:
 			printerr("SpacetimeDBClient: Reducer timed out before the response message arrived")
 		return
@@ -365,6 +366,7 @@ func _handle_parsed_message(message_resource: Resource):
 		if not procedure_call:
 			printerr("SpacetimeDBClient: Pending procedure call for request_id %s not found"% request_id)
 		procedure_call.on_response(message_resource)
+		procedure_call_response.emit(message_resource)
 	else:
 		print_log("SpacetimeDBClient: Received unhandled message resource type: " + message_resource.get_class())
 

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_schema.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_schema.gd
@@ -10,7 +10,7 @@ var debug_mode: bool = false # Controls verbose debug printing
 
 func _init(p_module_name: String, p_schema_path: String = "res://spacetime_bindings/schema", p_debug_mode: bool = false) -> void:
 	debug_mode = p_debug_mode
-	module_name = p_module_name.to_lower()
+	module_name = p_module_name.to_snake_case().to_lower()
 	module_types = {}
 	# Load module type files
 	_load_files("%s/types" % p_schema_path, module_types)
@@ -93,4 +93,4 @@ func get_core_type_script(core_type_name :StringName) -> GDScript:
 	return core_types.get(core_type_name)
 
 func get_type_of_table_name(table_name:StringName) -> StringName:
-	return module_table_name_to_type_name.get(table_name)
+	return module_table_name_to_type_name.get(table_name.to_snake_case(), &"")

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_schema.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_schema.gd
@@ -10,7 +10,7 @@ var debug_mode: bool = false # Controls verbose debug printing
 
 func _init(p_module_name: String, p_schema_path: String = "res://spacetime_bindings/schema", p_debug_mode: bool = false) -> void:
 	debug_mode = p_debug_mode
-	module_name = p_module_name.to_snake_case().to_lower()
+	module_name = p_module_name.to_snake_case()
 	module_types = {}
 	# Load module type files
 	_load_files("%s/types" % p_schema_path, module_types)


### PR DESCRIPTION
This change adds compatibility with C# syntax tables and also with procedures and reducers.

The idea is to parse all the table names to snake_case in order to match syntax with gdscript. This would affect also procedures and reducers modifying the function to snake_case but calling as C# syntax to the Spacetime server

In addition to this I added this signal procedure_call_response in `godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd` and the emission of `reducer_call_response` when we handled `ReducerResultMessage`. This is not needed for the compat with C# but I found this useful because from this I can get for example the timestamp of all the calls. If this is not part of the plans I can remove them.