### PR TITLE
feat(transport): adopt v3 WebSocket subprotocol

### DIFF
--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_connection.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_connection.gd
@@ -9,7 +9,20 @@ var _connection_requested: bool = false
 var _debug_mode: bool = false
 var version: String = "v1"
 # Protocol constants
-const BSATN_PROTOCOL = "v2.bsatn.spacetimedb"
+#
+# v3 (SpacetimeDB 2.2.0+, clockworklabs/SpacetimeDB PR #4761) does not
+# introduce a new outer message schema — it reuses the v2 ClientMessage /
+# ServerMessage values. The only on-the-wire change is that a single
+# WebSocket payload can contain one OR more BSATN-encoded v2 messages
+# concatenated back to back; senders may coalesce as they please, receivers
+# must decode sequentially until end-of-buffer.
+#
+# The existing BSATNDeserializer.process_bytes_and_extract_messages already
+# loops decoding messages from the incoming buffer until empty, so the
+# receive-side semantics work for free on v3. The send side keeps sending
+# one logical message per frame, which is still valid v3. A future
+# optimization is to coalesce client-side sends; not done in this PR.
+const BSATN_PROTOCOL = "v3.bsatn.spacetimedb"
 
 enum CompressionPreference { NONE = 0, BROTLI = 1, GZIP = 2 }
 var preferred_compression: CompressionPreference = CompressionPreference.NONE # Default to None


### PR DESCRIPTION
## Summary

Flips the WebSocket subprotocol identifier from `v2.bsatn.spacetimedb` to `v3.bsatn.spacetimedb` to opt into the v3 transport introduced in clockworklabs/SpacetimeDB 2.2.0 (PR https://github.com/clockworklabs/SpacetimeDB/pull/4761).

## Why this works as a one-line change

v3 is **not** a new message schema. It reuses the v2 `ClientMessage` / `ServerMessage` values as-is. The only on-the-wire change is that a single WebSocket payload may now contain one OR more BSATN-encoded v2 messages concatenated back to back. Senders may coalesce as they please; receivers must decode sequentially until end-of-buffer.

The existing `BSATNDeserializer.process_bytes_and_extract_messages` already loops decoding messages from the incoming buffer until empty, so the **receive-side semantics work for free**. The send side keeps sending one logical message per frame, which is **still valid v3** — a future optimization is to coalesce client-side sends, deliberately not part of this PR.

## Verification

Server handshake responds with `101 Switching Protocols` + `sec-websocket-protocol: v3.bsatn.spacetimedb`:

```
curl -s -i -N \
  -H "Connection: Upgrade" -H "Upgrade: websocket" \
  -H "Sec-WebSocket-Version: 13" \
  -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
  -H "Sec-WebSocket-Protocol: v3.bsatn.spacetimedb" \
  -H "Authorization: Bearer <token>" \
  http://localhost:3333/v1/database/<name>/subscribe
```

End-to-end verified in a downstream project via integration tests against a live SpacetimeDB 2.2.0 dev DB:
- anonymous connect + subscribe + `iter()` round-trip ✓
- overlapping-subscription audit (subscribe narrow, then subscribe wide; assert `on_insert` fires exactly once for the new row, zero additional times for the cached row — analogous to the Unreal SDK fix in clockworklabs/SpacetimeDB#4903) ✓

## Test plan

- [ ] Existing test-server-module flows continue to pass against a 2.2 server
- [ ] No regressions in the procedure / reducer / subscription codepaths (none expected — schema is unchanged)
- [ ] Hand-test connect-and-subscribe in any consuming project

## Notes for reviewers

- Not adding client-side outbound batching in this PR. Server batches naturally during high-throughput periods; client-side batching is a separate optimization that's worth measuring before adding complexity.
- The `version: String = "v1"` on line 10 is the HTTP path prefix (`/v1/database/...`), unrelated to the WebSocket subprotocol version — leaving untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)