### PR TITLE
feat(decompressor): add Brotli decoder for compression byte 1

### DIFF
--- a/godot-client/addons/SpacetimeDB/core/data_decompressor.gd
+++ b/godot-client/addons/SpacetimeDB/core/data_decompressor.gd
@@ -1,5 +1,12 @@
 class_name DataDecompressor extends RefCounted
 
+# Upper bound on the decompressed size of a single Brotli packet.
+# PackedByteArray.decompress_dynamic requires a hard cap. 64 MiB is
+# large enough to cover any reasonable single-frame BSATN payload from
+# a SpacetimeDB server; bigger payloads would already be refused by
+# the WebSocket layer's inbound_buffer_size on the way in.
+const BROTLI_MAX_DECOMPRESSED_BYTES: int = 64 * 1024 * 1024
+
 static func decompress_packet(compressed_bytes: PackedByteArray) -> PackedByteArray:
 	if compressed_bytes.is_empty():
 		return PackedByteArray()
@@ -33,3 +40,17 @@ static func decompress_packet(compressed_bytes: PackedByteArray) -> PackedByteAr
 			printerr("DataDecompressor Error: Failed while getting partial data.")
 			return []
 	return decompressed_data
+
+# Decompresses a Brotli-encoded payload using Godot's built-in
+# PackedByteArray.decompress_dynamic with FileAccess.COMPRESSION_BROTLI.
+# Godot doesn't ship a StreamPeerBrotli, so this is a one-shot non-streaming
+# call capped at BROTLI_MAX_DECOMPRESSED_BYTES.
+# Returns an empty PackedByteArray on failure (matches decompress_packet).
+static func decompress_brotli_packet(compressed_bytes: PackedByteArray) -> PackedByteArray:
+	if compressed_bytes.is_empty():
+		return PackedByteArray()
+	var decompressed: PackedByteArray = compressed_bytes.decompress_dynamic(
+		BROTLI_MAX_DECOMPRESSED_BYTES, FileAccess.COMPRESSION_BROTLI)
+	if decompressed.is_empty():
+		printerr("DataDecompressor Error: Brotli decompression returned empty payload (input %d bytes)." % compressed_bytes.size())
+	return decompressed

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
@@ -247,7 +247,7 @@ func _decompress_and_parse(raw_bytes: PackedByteArray) -> PackedByteArray:
 	var payload = raw_bytes.slice(1)
 	match compression:
 		0: pass
-		1: printerr("SpacetimeDBClient (Thread) : Brotli compression not supported!")
+		1: payload = DataDecompressor.decompress_brotli_packet(payload)
 		2: payload = DataDecompressor.decompress_packet(payload)
 	return payload
 


### PR DESCRIPTION
## Summary

`_decompress_and_parse` currently `printerr`s on wire-format compression byte 1 (Brotli) and drops the payload. SpacetimeDB 2.2 can negotiate Brotli compression (clockworklabs/SpacetimeDB#4561 server-side support). Wire byte 1 to a new `DataDecompressor.decompress_brotli_packet` that uses Godot's built-in `PackedByteArray.decompress_dynamic` with `FileAccess.COMPRESSION_BROTLI`.

## Why one-shot, not streaming

Godot ships `StreamPeerGZIP` but no `StreamPeerBrotli`, so streaming decoding isn't an option here. The non-streaming `decompress_dynamic` requires a hard cap on output size — I set `BROTLI_MAX_DECOMPRESSED_BYTES = 64 MiB`, which comfortably covers any single-frame BSATN payload from a SpacetimeDB server. Larger payloads would already be refused by the WebSocket layer's `inbound_buffer_size` before reaching here.

## Failure mode

Empty `PackedByteArray` on error — matches the existing `decompress_packet` contract so `_decompress_and_parse` callers don't need to change.

## Verification

End-to-end via unit tests in a downstream project:
- Short payload (27 bytes) round-trip via a known Brotli fixture (generated offline since Godot has no Brotli encoder) ✓
- Highly-redundant 5 KB → 40 bytes Brotli payload round-trip ✓
- Empty input → empty output ✓
- Garbage input → empty output, no crash ✓
- Existing Gzip path unaffected ✓

## Test plan

- [ ] Tested against a SpacetimeDB 2.2 server that emits Brotli-compressed payloads
- [ ] Confirm `_decompress_and_parse` matches case 1 cleanly with the new decoder

## Related

- Companion to https://github.com/flametime/Godot-SpacetimeDB-SDK/pull/124 (v3 transport). The two PRs are independent — either can land first — but together they unlock the full SpacetimeDB 2.2 wire-protocol feature set for Godot clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)