### PR TITLE
deeply nested Arrays support 

### DIFF
--- a/godot-client/addons/SpacetimeDB/codegen/schema_parser.gd
+++ b/godot-client/addons/SpacetimeDB/codegen/schema_parser.gd
@@ -411,6 +411,11 @@ static func _parse_type_info(
 			"type": "vec_%s" % inner_type,
 			"godot_type_hint": "PackedByteArray",
 		}
+		if inner_hint.begins_with("Array["):
+			return {
+			"type": "vec_%s" % inner_type,
+			"godot_type_hint": "Array[Array]",
+		}
 		return {
 			"type": "vec_%s" % inner_type,
 			"godot_type_hint": "Array[%s]" % inner_hint,
@@ -463,6 +468,8 @@ static func _parse_type_info(
 			"algebraic_type",
 			{}
 		)
+		prints("Sum Type failed to read", collect_all , JSON.stringify(sum_def, "\t"))
+
 		return _parse_type_info(first_variant, schema_types, module_pascal, collect_all)
 
 	if node.has("Product"):

--- a/godot-client/addons/SpacetimeDB/codegen/schema_parser.gd
+++ b/godot-client/addons/SpacetimeDB/codegen/schema_parser.gd
@@ -468,7 +468,7 @@ static func _parse_type_info(
 			"algebraic_type",
 			{}
 		)
-		prints("Sum Type failed to read", collect_all , JSON.stringify(sum_def, "\t"))
+		SpacetimePlugin.print_log("Sum Type failed to read: " + str(collect_all) + "\n" + JSON.stringify(sum_def, "\t"))
 
 		return _parse_type_info(first_variant, schema_types, module_pascal, collect_all)
 


### PR DESCRIPTION
now deeply nested arrays are supported too. 
they cap the godot typehint as Array[Array]
the bsatn typehint is complete.
the print is for future debug. i'm not entirely sure when it get's hit or if it is important that only the first variant get's taken.