### PR TITLE
reconnect_db, clear_db, thread cleanup

### DIFF
--- a/godot-client/addons/SpacetimeDB/core/bsatn_deserializer.gd
+++ b/godot-client/addons/SpacetimeDB/core/bsatn_deserializer.gd
@@ -686,7 +686,7 @@ func _parse_generic_type(spb:StreamPeerBuffer, bsatn_type:StringName)-> Variant:
 	elif bsatn_type.begins_with("vec_"):
 		var result_type_array: Array = []
 		var count = read_u32_le(spb)
-		for i in count:
+		for _i in count:
 			result_type_array.append(_parse_generic_type(spb, bsatn_type.trim_prefix("vec_")))
 		return result_type_array
 	elif bsatn_type.begins_with("ret_"):
@@ -709,7 +709,7 @@ func _parse_generic_type(spb:StreamPeerBuffer, bsatn_type:StringName)-> Variant:
 			return primitive_reader.call(spb)
 
 		_set_error("unknown bsatn_type: %s" % bsatn_type )
-	if not script or not script.can_instantiate():
+	if not script:
 		_set_error("script: %s is empty or can't instantiate" % script)
 
 	var result_resource := script.new()

--- a/godot-client/addons/SpacetimeDB/core/local_database.gd
+++ b/godot-client/addons/SpacetimeDB/core/local_database.gd
@@ -243,7 +243,18 @@ func apply_table_update(table_update: TableUpdateData) -> Dictionary[String,Arra
 				"deletes": deletes_to_emit}
 	return changes
 
-
+func clear_local_db():
+	var all_deletes_to_emit: Array[Dictionary]
+	for table in _tables:
+		var deletes_to_emit:Array
+		for row in get_all_rows(table):
+			deletes_to_emit.append([row])
+		_tables[table].clear()
+		all_deletes_to_emit.append({"table_name": [table],
+				"inserts": [],
+				"updates": [],
+				"deletes": deletes_to_emit})
+	emit_db_callbacks(all_deletes_to_emit)
 
 # --- Access Methods ---
 func get_row_by_pk(table_name: String, primary_key_value) -> _ModuleTableType:

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
@@ -195,7 +195,8 @@ func _save_token(token_to_save: String):
 
 # --- WebSocket Message Handling ---
 func _process(_delta: float) -> void:
-	_process_results_asynchronously()
+	if use_threading and is_connected_db():
+		_process_results_asynchronously()
 
 func _on_websocket_message_received(raw_bytes: PackedByteArray):
 	if not _is_initialized: return

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
@@ -22,7 +22,6 @@ var _result_queue: Array[Resource] = []
 var _result_mutex: Mutex
 var _packet_mutex: Mutex
 var _thread_should_exit: bool = false
-var _message_limit_in_frame: int = 5
 
 var connection_options: SpacetimeDBConnectionOptions
 
@@ -51,7 +50,7 @@ var _pending_one_off_query_callbacks: Dictionary[int,SpacetimeDBPendingOneOffQue
 signal connected(identity: PackedByteArray, token: String)
 signal disconnected
 signal connection_error(code: int, reason: String)
-signal database_initialized # Emitted after InitialSubscription is processed
+signal database_initialized
 signal database_update(table_update: TableUpdateData) # Emitted for each table update
 
 # From LocalDatabase
@@ -60,7 +59,7 @@ signal row_updated(table_name: String, old_row: Resource, new_row: Resource)
 signal row_deleted(table_name: String, row: Resource)
 signal row_transactions_completed(table_name: String)
 
-signal reducer_call_response(response: Resource) # TODO: Define response resource
+signal reducer_call_response(response: ReducerResultMessage)
 signal reducer_call_timeout(request_id: int) # TODO: Implement timeout logic
 signal procedure_call_response(response: ProcedureResultMessage)
 signal transaction_update_received(update: TransactionUpdateMessage)
@@ -76,16 +75,20 @@ func _exit_tree():
 		deserializer_worker.wait_to_finish()
 		deserializer_worker = null
 
+# virtual func _init_db()
+func _init_db(local_db: LocalDatabase) -> void:
+	pass
+
 func print_log(log_message: String):
 	if debug_mode:
 		print(log_message)
 
 func initialize_and_connect():
 	if _is_initialized:
+		printerr("SpacetimeDBClient: already Initialized. something went wrong.")
 		return
 
 	print_log("SpacetimeDBClient: Initializing...")
-
 	# 1. Load Schema
 	var module_name: String = get_meta("module_name", "")
 	var schema := SpacetimeDBSchema.new(module_name, schema_path, debug_mode)
@@ -120,15 +123,16 @@ func initialize_and_connect():
 	_connection.name = "Connection"
 	add_child(_connection)
 
+	# 6. wait a frame to make sure everything is ready.
+	await get_tree().process_frame
 	_is_initialized = true
 	print_log("SpacetimeDBClient: Initialization complete.")
+	self.database_initialized.emit()
 
-	# 6. Get Token and Connect
+	# 7. Get Token and Connect
 	_load_token_or_request()
 
-# virtual func _init_db()
-func _init_db(local_db: LocalDatabase) -> void:
-	pass
+
 
 func _load_token_or_request():
 	if not _token.is_empty():
@@ -216,7 +220,7 @@ func _thread_loop() -> void:
 			continue
 		if _packet_queue.size() >1:
 			print_log("BSATN-Thread: package_queue: " + str(_packet_queue.size()))
-		var packet_to_process: PackedByteArray = _packet_queue.pop_back()
+		var packet_to_process: PackedByteArray = _packet_queue.pop_front()
 		_packet_mutex.unlock()
 
 		var message_resource: Resource = null
@@ -229,23 +233,26 @@ func _thread_loop() -> void:
 			_result_mutex.unlock()
 
 func _process_results_asynchronously():
-	if use_threading and not _result_mutex: return
+	if use_threading and not _result_mutex:
+		printerr("SpacetimeDBClient: Threading setup corrupted: _result_mutex missing")
+		return
 
 	if use_threading: _result_mutex.lock()
 
 	if _result_queue.is_empty():
 		if use_threading: _result_mutex.unlock()
 		return
-
-	var processed_count = 0
-
-	while not _result_queue.is_empty() and processed_count < _message_limit_in_frame:
-		_handle_parsed_message(_result_queue.pop_front())
-		if _result_queue.size() >= 1:
-			print_log("BSATN-Thread: result_queue: " + str(_result_queue.size()))
-		processed_count += 1
-
+	# shallow copy the queue to reduce block time.
+	var result_queue_copy := _result_queue.duplicate()
+	_result_queue.clear()
 	if use_threading: _result_mutex.unlock()
+
+	while not result_queue_copy.is_empty():
+		_handle_parsed_message(result_queue_copy.pop_front())
+		if result_queue_copy.size() >= 1:
+			print_log("BSATN-Thread: result_queue: " + str(result_queue_copy.size()))
+
+
 
 func _decompress_and_parse(raw_bytes: PackedByteArray) -> PackedByteArray:
 	var compression = raw_bytes[0]
@@ -278,15 +285,12 @@ func _handle_parsed_message(message_resource: Resource):
 
 	if message_resource is IdentityTokenMessage:
 		var identity_token: IdentityTokenMessage = message_resource
-		print_log("SpacetimeDBClient: Received Identity Token.")
+		print_log("SpacetimeDBClient: Received Identity Token Message.")
 		_identity = identity_token.identity
 		if not _token and identity_token.token:
 			_token = identity_token.token
 		_connection_id = identity_token.connection_id
 		self.connected.emit(_identity, _token)
-		if not _received_initial_subscription:
-			_received_initial_subscription = true
-			self.database_initialized.emit()
 
 	elif message_resource is SubscribeAppliedMessage:
 		var message: SubscribeAppliedMessage = message_resource
@@ -426,20 +430,21 @@ func connect_db(host_url: String, database_name: String, options: SpacetimeDBCon
 		_load_token_or_request()
 
 func disconnect_db():
-	_token = ""
 	if _connection:
 		_connection.disconnect_from_server()
-
 
 func is_connected_db() -> bool:
 	return _connection and _connection.is_connected_db()
 
-# The untyped local database instance, use the generated .Db property for querying
+## The untyped local database instance, use the generated .Db property for querying
 func get_local_database() -> LocalDatabase:
 	return _local_db
 
 func get_local_identity() -> PackedByteArray:
 	return _identity
+
+func get_token() -> StringName:
+	return _token
 
 func subscribe(queries: PackedStringArray) -> SpacetimeDBSubscription:
 	if not is_connected_db():

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
@@ -430,9 +430,20 @@ func connect_db(host_url: String, database_name: String, options: SpacetimeDBCon
 		# Already initialized, just need token and connect
 		_load_token_or_request()
 
-func disconnect_db():
-	if _connection:
-		_connection.disconnect_from_server()
+func reconnect_db(clear_db: bool = false):
+	if not _is_initialized:
+		printerr("SpacetimeDBClient: not initialized. connect with connect_db() first")
+	if _connection.is_connected_db():
+		printerr("SpacetimeDBClient: Already connected")
+	if clear_db:
+		_local_db.clear_local_db()
+	_load_token_or_request()
+
+func disconnect_db(clear_db: bool = false):
+	if not _connection.is_connected_db(): return
+	if clear_db:
+		_local_db.clear_local_db()
+	_connection.disconnect_from_server()
 
 func is_connected_db() -> bool:
 	return _connection and _connection.is_connected_db()

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
@@ -9,6 +9,7 @@ class_name SpacetimeDBClient extends Node
 @export var auto_request_token: bool = true
 @export var token_save_path: String = "user://spacetimedb_token.dat" # Use a more specific name
 @export var one_time_token: bool = false
+@export var save_token: bool = true
 @export var compression: SpacetimeDBConnection.CompressionPreference
 @export var debug_mode: bool = true
 @export var current_subscriptions: Dictionary[int, SpacetimeDBSubscription]
@@ -130,7 +131,7 @@ func _init_db(local_db: LocalDatabase) -> void:
 	pass
 
 func _load_token_or_request():
-	if _token:
+	if not _token.is_empty():
 		# If token is already set, use it
 		_on_token_received(_token)
 		return
@@ -166,7 +167,8 @@ func _generate_connection_id() -> String:
 func _on_token_received(received_token: String):
 	print_log("SpacetimeDBClient: Token acquired.")
 	self._token = received_token
-	_save_token(received_token)
+	if save_token:
+		_save_token(received_token)
 	var conn_id = _generate_connection_id()
 	# Pass token to components that need it
 	_connection.set_token(self._token)

--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_connection_options.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_connection_options.gd
@@ -1,15 +1,28 @@
 class_name SpacetimeDBConnectionOptions extends Resource
+## helper class for the Websocket connection builder.
 
+## Brotli not supported yet
 const CompressionPreference = SpacetimeDBConnection.CompressionPreference
 
+## Brotli not supported yet
 var compression: CompressionPreference = CompressionPreference.NONE
+## Use a thread for the BSATN parsing. Adds 1-2 frames delay.
 var threading: bool = true
+## Get a new token for the connection.
 var one_time_token: bool = true
+## Save the token to the user:// folder
+var save_token: bool = true
+## Overwrite the used token
 var token: String = ""
+## Tells the server to wait for Persistance. Adds around 20ms to 50ms server latency.
 var confirmed_reads: bool = false
+## Write debug prints to Output. Can be quite spammy on fast redcer calls.
 var debug_mode: bool = false
+## Adds Websocket monitors to the Debugger/Monitors tab
 var monitor_mode: bool = false
+## max websocket message buffer size
 var inbound_buffer_size: int = 1024 * 1024 * 2 # 2MB
+## max websocket message buffer size
 var outbound_buffer_size: int = 1024 * 1024 * 2 # 2MB
 
 func set_all_buffer_size(size: int):

--- a/godot-client/example_code/integration_tests.gd
+++ b/godot-client/example_code/integration_tests.gd
@@ -7,7 +7,7 @@ func _ready() -> void:
 	#options.one_time_token = true # <--- anonymous-like. set to false to persist
 	options.debug_mode = true # <--- enables lots of additional debug prints and warnings
 	options.compression = SpacetimeDBConnection.CompressionPreference.GZIP
-	options.threading = true
+	options.threading = false
 	options.monitor_mode = true
 	# Increase buffer size. In general, you don't need this.
 	# options.set_all_buffer_size(1024 * 1024 * 2)

--- a/godot-client/example_code/integration_tests.gd
+++ b/godot-client/example_code/integration_tests.gd
@@ -4,7 +4,7 @@ extends Control
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	var options :SpacetimeDBConnectionOptions = SpacetimeDBConnectionOptions.new()
-	options.one_time_token = true # <--- anonymous-like. set to false to persist
+	#options.one_time_token = true # <--- anonymous-like. set to false to persist
 	options.debug_mode = true # <--- enables lots of additional debug prints and warnings
 	options.compression = SpacetimeDBConnection.CompressionPreference.GZIP
 	options.threading = true

--- a/godot-client/example_code/integration_tests.gd
+++ b/godot-client/example_code/integration_tests.gd
@@ -60,7 +60,7 @@ func _on_spacetimedb_database_init() -> void:
 
 
 func _on_button_pressed() -> void:
-	var call1 : SpacetimeDBReducerCall = SpacetimeDB.Main.reducers.start_integration_tests(MainTestNestedType.create(Option.none()))
+	var call1 : SpacetimeDBReducerCall = SpacetimeDB.Main.reducers.start_integration_tests(MainTestNestedType.create(Option.none(), MainTestDeepArrayType.new()))
 	call1.on_ok.connect(func(update:ReducerResultMessage) -> void: print("Reducer call1 returned Ok with %s" % update))
 	var time := Time.get_ticks_usec()
 	await call1.response

--- a/godot-client/main.gd
+++ b/godot-client/main.gd
@@ -6,7 +6,7 @@ func _ready() -> void:
 	options.one_time_token = true # <--- anonymous-like. set to false to persist
 	options.debug_mode = true # <--- enables lots of additional debug prints and warnings
 	options.compression = SpacetimeDBConnection.CompressionPreference.GZIP
-	options.threading = true
+	options.threading = false
 	options.monitor_mode = true
 	# Increase buffer size. In general, you don't need this.
 	# options.set_all_buffer_size(1024 * 1024 * 2)

--- a/godot-client/scenes/conneciton_tester.gd
+++ b/godot-client/scenes/conneciton_tester.gd
@@ -1,0 +1,61 @@
+extends Control
+
+@onready var label: Label = $GridContainer/Label
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+
+
+func _on_button_pressed() -> void:
+	#connect
+	var options :SpacetimeDBConnectionOptions = SpacetimeDBConnectionOptions.new()
+	#options.one_time_token = true # <--- anonymous-like. set to false to persist
+	options.debug_mode = true # <--- enables lots of additional debug prints and warnings
+	options.compression = SpacetimeDBConnection.CompressionPreference.GZIP
+	options.threading = false
+	options.monitor_mode = true
+	# Increase buffer size. In general, you don't need this.
+	# options.set_all_buffer_size(1024 * 1024 * 2)
+	# Disable threading (e.g., for web builds)
+	# options.threading = false
+
+	SpacetimeDB.Main.connect_db( # WARNING <--- replace 'Main' with your module name
+		"http://127.0.0.1:3000", # WARNING <--- replace it with your url
+		"main", # WARNING <--- replace it with your database name
+		options
+	)
+	SpacetimeDB.Main.connected.connect(_on_spacetimedb_connected)
+	SpacetimeDB.Main.disconnected.connect(_on_spacetimedb_disconnected)
+	SpacetimeDB.Main.connection_error.connect(_on_spacetimedb_connection_error)
+
+func _on_spacetimedb_connected(_identity: PackedByteArray, _token: String) -> void:
+	label.text = "Connected"
+
+func _on_spacetimedb_disconnected() -> void:
+	label.text = "Disonnected"
+
+func _on_spacetimedb_connection_error(code: int, reason: String) -> void:
+	label.text = "Connection Error: "+ reason+ " Code: "+ str(code)
+
+func _on_button_2_pressed() -> void:
+	#reconnect
+	SpacetimeDB.Main.reconnect_db(true)
+	label.text = "Reconnecting"
+
+func _on_button_3_pressed() -> void:
+	# disconnect
+	SpacetimeDB.Main.disconnect_db()
+	label.text = "Disconnecting"
+
+
+func _on_button_4_pressed() -> void:
+	SpacetimeDB.Main.disconnect_db()
+	await SpacetimeDB.Main.disconnected
+	get_tree().quit()
+	# Replace with function body.

--- a/godot-client/scenes/conneciton_tester.gd.uid
+++ b/godot-client/scenes/conneciton_tester.gd.uid
@@ -1,0 +1,1 @@
+uid://c5he8m24e20he

--- a/godot-client/scenes/conneciton_tester.tscn
+++ b/godot-client/scenes/conneciton_tester.tscn
@@ -1,0 +1,42 @@
+[gd_scene format=3 uid="uid://dmxc01tceue5g"]
+
+[ext_resource type="Script" uid="uid://c5he8m24e20he" path="res://scenes/conneciton_tester.gd" id="1_ghv5y"]
+
+[node name="Control" type="Control" unique_id=2009103807]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_ghv5y")
+
+[node name="GridContainer" type="GridContainer" parent="." unique_id=1074322560]
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="Label" type="Label" parent="GridContainer" unique_id=1544555339]
+layout_mode = 2
+text = "disconnected"
+
+[node name="Button" type="Button" parent="GridContainer" unique_id=1777804442]
+layout_mode = 2
+text = "Connect"
+
+[node name="Button2" type="Button" parent="GridContainer" unique_id=1559127518]
+layout_mode = 2
+text = "Reconnect"
+
+[node name="Button3" type="Button" parent="GridContainer" unique_id=800483017]
+layout_mode = 2
+text = "Disconnect"
+
+[node name="Button4" type="Button" parent="GridContainer" unique_id=1598661236]
+layout_mode = 2
+text = "Quit"
+
+[connection signal="pressed" from="GridContainer/Button" to="." method="_on_button_pressed"]
+[connection signal="pressed" from="GridContainer/Button2" to="." method="_on_button_2_pressed"]
+[connection signal="pressed" from="GridContainer/Button3" to="." method="_on_button_3_pressed"]
+[connection signal="pressed" from="GridContainer/Button4" to="." method="_on_button_4_pressed"]


### PR DESCRIPTION
i added a reconnect function that doesn't require the Options to be send again. it reuses the one used in the first connect_db call.
i added a clear_db function to the local_db for the reconnect_db and disconnect_db functions (default false) to clear out the local_db of all rows and call the delete callbacks for all rows.