### PR TITLE
Deterministic binding UIDs

### DIFF
--- a/godot-client/addons/SpacetimeDB/codegen/codegen.gd
+++ b/godot-client/addons/SpacetimeDB/codegen/codegen.gd
@@ -75,12 +75,10 @@ func generate_bindings() -> Array[String]:
 	_write_text(autoload_output_file_path, autoload_content)
 	generated_files.append(autoload_output_file_path)
 
-	for generated_file in generated_files:
-		_write_deterministic_uid(generated_file)
-
-	SpacetimePlugin.print_log("Generated files:")
-	for generated_file in generated_files:
-		SpacetimePlugin.print_log(generated_file)
+    SpacetimePlugin.print_log("Generated files:")
+    for generated_file in generated_files:
+        _write_deterministic_uid(generated_file)
+        SpacetimePlugin.print_log(generated_file)
 
 	return generated_files
 

--- a/godot-client/addons/SpacetimeDB/codegen/codegen.gd
+++ b/godot-client/addons/SpacetimeDB/codegen/codegen.gd
@@ -61,12 +61,13 @@ func _param_bsatn_literal(raw_type: String) -> String:
 func generate_bindings() -> Array[String]:
 	var generated_files: Array[String] = []
 
-	for module_name: String in _plugin_config.module_configs:
+	var sorted_module_names: Array[String] = _plugin_config.module_configs.keys()
+	sorted_module_names.sort()
+
+	for module_name: String in sorted_module_names:
 		generated_files.append_array(_generate_module_bindings(module_name))
 
-	var autoload_content := _generate_autoload_gdscript(
-		_plugin_config.module_configs.keys()
-	)
+	var autoload_content := _generate_autoload_gdscript(sorted_module_names)
 	var autoload_output_file_path := "%s/%s" % [
 		_schema_path,
 		SpacetimePlugin.AUTOLOAD_FILE_NAME,
@@ -74,11 +75,37 @@ func generate_bindings() -> Array[String]:
 	_write_text(autoload_output_file_path, autoload_content)
 	generated_files.append(autoload_output_file_path)
 
+	for generated_file in generated_files:
+		_write_deterministic_uid(generated_file)
+
 	SpacetimePlugin.print_log("Generated files:")
 	for generated_file in generated_files:
 		SpacetimePlugin.print_log(generated_file)
 
 	return generated_files
+
+
+## Derive a stable ResourceUID id from the script's res:// path via FNV-1a 64-bit.
+## Same path -> same id on every machine and every regen, so the generated
+## bindings can be gitignored: scene/.tres `ext_resource uid="..."` references
+## stay valid after a fresh clone + regenerate, with no diff churn. The 63-bit
+## mask keeps the id positive and away from ResourceUID.INVALID_ID (-1).
+func _stable_uid_id(res_path: String) -> int:
+	var hash: int = -3750763034362895579  # 0xcbf29ce484222325 (FNV offset basis as i64)
+	for byte: int in res_path.to_utf8_buffer():
+		hash = (hash ^ byte) * 0x100000001b3  # FNV prime; wraps at i64, that's fine
+	return hash & 0x7FFFFFFFFFFFFFFF
+
+
+## Write a `<path>.uid` sidecar with the deterministic id and sync the editor's
+## in-memory uid cache so a live regen doesn't re-mint a random uid.
+func _write_deterministic_uid(gd_path: String) -> void:
+	var id: int = _stable_uid_id(gd_path)
+	_write_text("%s.uid" % gd_path, ResourceUID.id_to_text(id))
+	if ResourceUID.has_id(id):
+		ResourceUID.set_id(id, gd_path)
+	else:
+		ResourceUID.add_id(id, gd_path)
 
 
 func _generate_module_bindings(module_name: String) -> Array[String]:

--- a/godot-client/addons/SpacetimeDB/codegen/schema_parser.gd
+++ b/godot-client/addons/SpacetimeDB/codegen/schema_parser.gd
@@ -54,6 +54,13 @@ static func parse_schema(p_schema: Dictionary, module_name: String) -> Spacetime
 	var schema_procedures: Array = sections.get("Procedures", [])
 	var schema_views: Array = sections.get("Views", [])
 
+	# Server schema sections are HashMap-backed; iteration order varies per publish.
+	# Sort once at parse time so downstream codegen output is deterministic.
+	_sort_by_source_name(schema_tables)
+	_sort_by_source_name(schema_reducers)
+	_sort_by_source_name(schema_procedures)
+	_sort_by_source_name(schema_views)
+
 	var parsed_schema := SpacetimeParsedSchema.new()
 	parsed_schema.module = module_pascal
 
@@ -224,6 +231,9 @@ static func parse_schema(p_schema: Dictionary, module_name: String) -> Spacetime
 					% [unique_field_idx, table_name, target_type_def.struct.size()]
 				)
 
+		parsed_unique_indexes.sort_custom(func(a, b):
+			return String(a["constraint_name"]) < String(b["constraint_name"])
+		)
 		table_data["unique_indexes"] = parsed_unique_indexes
 
 		var is_public: bool = not table_info.get("table_access", {}).has("Private")
@@ -309,6 +319,10 @@ static func parse_schema(p_schema: Dictionary, module_name: String) -> Spacetime
 
 		parsed_tables_list.append(new_table_dict)
 
+	parsed_tables_list.sort_custom(func(a, b):
+		return String(a["name"]) < String(b["name"])
+	)
+
 	SpacetimePlugin.print_log("Schema parser finished")
 	parsed_schema.types = parsed_types_list
 	parsed_schema.tables = parsed_tables_list
@@ -328,6 +342,10 @@ static func _section_typespace(sections: Dictionary) -> Array:
 	if typespace_section is Dictionary:
 		return typespace_section.get("types", [])
 	return []
+
+static func _sort_by_source_name(arr: Array) -> void:
+	arr.sort_custom(func(a, b): return _source_name(a) < _source_name(b))
+
 
 static func _source_name(value: Variant) -> String:
 	if value is Dictionary:

--- a/godot-client/addons/SpacetimeDB/spacetime.gd
+++ b/godot-client/addons/SpacetimeDB/spacetime.gd
@@ -145,6 +145,7 @@ func _on_generate_schema():
 	var generated_files := codegen.generate_bindings()
 
 	_cleanup_unused_classes(BINDINGS_SCHEMA_PATH, generated_files)
+	_check_uid_collisions()
 
 	if DirAccess.dir_exists_absolute(LEGACY_DATA_PATH):
 		print_log("Removing legacy data directory: %s" % LEGACY_DATA_PATH)
@@ -181,6 +182,40 @@ func _cleanup_unused_classes(dir_path: String = "res://schema", files: Array[Str
 	var subfolders = dir.get_directories()
 	for folder in subfolders:
 		_cleanup_unused_classes(dir_path + "/" + folder, files)
+
+
+## Walks `dir_path` recursively and appends every file ending in `suffix` to `out`.
+func _collect_files_by_suffix(dir_path: String, suffix: String, out: Array[String]) -> void:
+	var dir := DirAccess.open(dir_path)
+	if not dir:
+		return
+	for file_name: String in dir.get_files():
+		if file_name.ends_with(suffix):
+			out.append("%s/%s" % [dir_path, file_name])
+	for sub: String in dir.get_directories():
+		_collect_files_by_suffix("%s/%s" % [dir_path, sub], suffix, out)
+
+
+## Deterministic binding uids share the full 63-bit id space with Godot's
+## randomly-minted uids, so a clash is possible (~1e-13) — and because our ids
+## are deterministic, a clash would reproduce on every clone. Scan the whole
+## project for duplicate uid ids and report any that exist. If this ever fires,
+## salt `SpacetimeCodegen._stable_uid_id` (e.g. prefix a version byte) and regenerate.
+func _check_uid_collisions() -> void:
+	var uid_files: Array[String] = []
+	_collect_files_by_suffix("res://", ".uid", uid_files)
+	var seen: Dictionary[int, String] = {}
+	for path: String in uid_files:
+		var text := FileAccess.get_file_as_string(path).strip_edges()
+		if text.is_empty():
+			continue
+		var id: int = ResourceUID.text_to_id(text)
+		if id == ResourceUID.INVALID_ID:
+			continue
+		if seen.has(id):
+			print_err("UID collision (%s): %s <-> %s" % [text, seen[id], path])
+		else:
+			seen[id] = path
 
 static func clear_logs():
 	if instance != null and is_instance_valid(instance.ui):


### PR DESCRIPTION
## Summary

Make the generated GDScript bindings byte-for-byte reproducible across machines
and across regenerations, so a project can safely `.gitignore` the generated
`schema/` folder without breaking scene/`.tres` resource references or churning
diffs. Adds a project-wide UID-collision guard as a safety net.

## Motivation

Today the codegen mints a **random** `ResourceUID` for every generated script,
and the schema is parsed in whatever order the server returns its sections
(HashMap-backed, so the order varies between publishes). Two consequences:

1. **Bindings can't be gitignored.** A scene or `.tres` that references a
   generated binding stores `ext_resource uid="uid://..."`. Because the UID is
   random per machine/regen, a teammate who regenerates gets different UIDs and
   every reference breaks.
2. **Noisy diffs.** Even when bindings are committed, re-running codegen
   reshuffles declaration order and re-mints UIDs, producing large meaningless
   diffs.

Deriving each script's UID deterministically from its `res://` path, plus
sorting the schema before generation, fixes both: the same path yields the same
UID on every machine and every regen, and the generated text is stable.

## What changed

- **`codegen/schema_parser.gd`** — sort for determinism only:
  - sort the schema sections (tables, reducers, procedures, views) by a stable
    source-name key at parse time (`_sort_by_source_name` helper);
  - sort each table's `unique_indexes` by `constraint_name`;
  - sort the final `parsed_tables_list` by table name.
- **`codegen/codegen.gd`**:
  - sort module names before generation so the autoload output is stable;
  - `_stable_uid_id(res_path)` — FNV-1a 64-bit hash of the `res://` path, masked
    to 63 bits (stays positive, never `ResourceUID.INVALID_ID`);
  - `_write_deterministic_uid(gd_path)` — writes the `.uid` sidecar from that id
    and syncs the editor's in-memory `ResourceUID` cache so a live regen doesn't
    re-mint a random id. Called for every generated file.
- **`spacetime.gd`**:
  - `_check_uid_collisions()` — after generation, scans the whole project for
    duplicate UID ids and reports any collision (deterministic ids would
    otherwise reproduce a clash on every clone). If it ever fires, salt
    `SpacetimeCodegen._stable_uid_id` and regenerate.
  - `_collect_files_by_suffix(dir, suffix, out)` — small recursive helper used by
    the collision scan.

## Testing notes

  1. Generate bindings, note the `.uid` values.
  2. Delete `schema/`, regenerate — the `.uid` values should be identical.
  3. Regenerate on a second machine / fresh clone — still identical.
  4. Confirm `_check_uid_collisions()` logs nothing on a clean project.
- FNV-1a is computed with GDScript 64-bit integer wraparound, which is
  intentional (matches the standard 64-bit FNV-1a modulo 2^64).

## Open questions for the maintainer

- Is opt-in vs. always-on desired? This branch makes deterministic UIDs the
  default behavior of codegen. If you'd rather gate it behind a plugin-config
  flag, that's an easy follow-up.
- The collision scan walks all of `res://` on every generate. On very large
  projects that's a bit of I/O; happy to scope it to the bindings dir + a
  configurable set of roots if you prefer.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
