### PR TITLE
Keep deserializer worker on threaded Web exports

### DIFF
--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
@@ -413,11 +413,13 @@ func connect_db(host_url: String, database_name: String, options: SpacetimeDBCon
 	self.debug_mode = options.debug_mode
 	self.use_threading = options.threading
 
-	if OS.has_feature("web") and use_threading == true:
-		push_error("Threads are not supported on Web. Threading has been disabled.")
+	if use_threading == true and not OS.has_feature("threads"):
+		push_error("Threads not supported by this build (non-threaded export). Threading has been disabled.")
 		use_threading = false
 
-	if use_threading:
+	# Reuse the existing worker on reconnect (connect_db re-called) — starting a
+	# second thread would race the same packet queue.
+	if use_threading and deserializer_worker == null:
 		_packet_mutex = Mutex.new()
 		_packet_semaphore = Semaphore.new()
 		_result_mutex = Mutex.new()


### PR DESCRIPTION
## Summary

Keep the BSATN deserializer worker thread on **threaded** Web exports, instead of force-disabling it on every Web build.

## Motivation

The current guard disables threading whenever `OS.has_feature("web")` is true. But Web exports built with threads enabled (SharedArrayBuffer / cross-origin isolated) *do* support threads — they were being forced onto the slower main-thread deserialization path unnecessarily. Gating on the actual `"threads"` feature keeps the worker where it's supported and only falls back on genuinely non-threaded builds.

The same block also gained a guard so a reconnect (calling `connect_db` again) reuses the existing worker instead of starting a second thread that races the same packet queue.

## What changed

`core/spacetimedb_client.gd` only:

- `if use_threading == true and not OS.has_feature("threads")` replaces the `OS.has_feature("web")` hard-disable, with an updated `push_error` message.
- worker creation guarded on `deserializer_worker == null` for reconnect safety.

## Testing notes

- Desktop: unchanged behavior — threads still enabled, single worker, subscription + reducer round-trip verified against the example project.
- Reconnect: `connect_db` re-called after `disconnect_db` reuses the same worker thread (verified: same Thread instance, no second thread, data flows again).
- Threaded Web export: expected to keep the worker (previously force-disabled). *Not runtime-tested here — requires a COOP/COEP cross-origin-isolated web host.*
- Non-threaded build: graceful fallback with the updated `push_error` message.
---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
