### PR TITLE
SpacetimeAuth OIDC token exchange node + JWT helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This SDK provides the necessary tools to integrate your Godot Engine project wit
 -   [How to install the SpacetimeDB SDK addon](docs/installation.md)
 -   [Quick Start guide](docs/quickstart.md)
 -   [API Reference](docs/api.md)
+-   [Steam sign-in with GodotSteam (SpacetimeAuth)](docs/spacetimeauth-godotsteam.md)
 
 ## Limitations & TODO
 

--- a/docs/spacetimeauth-godotsteam.md
+++ b/docs/spacetimeauth-godotsteam.md
@@ -1,0 +1,313 @@
+# SpacetimeAuth + GodotSteam: Steam sign-in for SpacetimeDB
+
+How to turn a **Steam** login into a **SpacetimeDB** connection using the SDK's
+`SpacetimeAuth` node ([`addons/SpacetimeDB/nodes/spacetime_auth/spacetime_auth.gd`](../godot-client/addons/SpacetimeDB/nodes/spacetime_auth/spacetime_auth.gd))
+and [GodotSteam](https://godotsteam.com/).
+
+The flow is provider-agnostic — Steam is one grant type. The same node handles
+Google Play, Epic, Apple, Discord, etc.; only the `grant_type` string and the
+credential fields change.
+
+```
+GodotSteam                     SpacetimeAuth node                SpacetimeDB
+──────────                     ─────────────────                ───────────
+getAuthTicketForWebApi   ─▶  exchange(grant_type, fields)  ─▶  POST /oidc/token
+   (Steam WebAPI ticket)         │                                 │
+                                 ▼                                 ▼
+                            ExchangeResult.id_token  ─────▶  connect with token
+                            (a SpacetimeAuth JWT)            (SpacetimeDBConnectionOptions.token)
+```
+
+---
+
+## Prerequisites
+
+1. **SDK addon enabled** (`addons/SpacetimeDB`) — gives you `SpacetimeAuth`,
+   `SpacetimeDBClient`, `SpacetimeDBConnectionOptions`, and `JwtHelper`.
+2. **GodotSteam** installed and `Steam.steamInitEx()` succeeded, with your
+   Steam **App ID** set (`steam_appid.txt` during dev, or the launched app).
+3. A **SpacetimeAuth `client_id`** for your game, and your Steam app registered
+   with SpacetimeAuth for the `steam-ticket` grant. Store the `client_id` in a
+   project setting or config — never hard-code it in a shipped scene you can't
+   rotate.
+
+---
+
+## The `SpacetimeAuth` node API
+
+```gdscript
+class_name SpacetimeAuth extends Node
+
+# await this; also emitted as `exchange_completed(result)`
+func exchange(grant_type: String, extra_fields: Dictionary, client_id: String) -> ExchangeResult
+
+class ExchangeResult extends RefCounted:
+    var id_token: String   # the JWT to connect with (empty on failure)
+    var expires_in: int    # seconds until the id_token expires
+    var error: String      # non-empty on failure
+    func is_successful() -> bool
+```
+
+Exported knobs (all optional, sensible defaults):
+
+| export | default | purpose |
+|---|---|---|
+| `token_url` | `https://auth.spacetimedb.com/oidc/token` | override for a self-hosted SpacetimeAuth |
+| `request_timeout_seconds` | `15.0` | bounds a network hang (DNS/TLS stall) |
+| `max_attempts` | `4` | transient failures (transport error / 5xx) retry with exponential backoff; a 2xx/4xx is authoritative and never retried |
+| `base_retry_delay_seconds` / `max_retry_delay_seconds` | `0.5` / `4.0` | backoff bounds |
+| `redact_fields` | `["id_token","access_token","refresh_token","token","code","ticket","client_secret"]` | field **values** scrubbed from any error body echoed to the log |
+| `debug_mode` | `false` | set `true` to log the request/response summary |
+
+**The node owns its own `HTTPRequest`** — you just add it to the tree and
+`await`. It must be inside the scene tree before you call `exchange()`.
+
+> **Redaction gotcha (Steam):** the default `redact_fields` has `"ticket"`, but
+> the Steam credential field is named `steam_ticket`, and matching is by exact
+> field name. **Append `"steam_ticket"`** (shown below) so the hex ticket never
+> lands in a log verbatim.
+
+---
+
+## Minimal example
+
+The happy path, no error handling, to show the shape:
+
+```gdscript
+# Assumes Steam is initialized and a WebAPI ticket has been obtained (see below).
+var auth := SpacetimeAuth.new()
+add_child(auth)                                  # must be in the tree
+auth.redact_fields.append("steam_ticket")        # keep the ticket out of logs
+
+var result := await auth.exchange(
+    "urn:spacetimeauth:steam-ticket",            # Steam grant type
+    {
+        "steam_ticket": ticket_bytes.hex_encode(),
+        "steam_app_id": str(app_id),
+    },
+    client_id,                                   # your SpacetimeAuth client_id
+)
+auth.queue_free()
+
+if result.is_successful():
+    print("id_token: %d chars, expires_in=%d" % [result.id_token.length(), result.expires_in])
+    # -> hand result.id_token to your SpacetimeDB connect (see "Connecting" below)
+else:
+    push_error("SpacetimeAuth exchange failed: %s" % result.error)
+```
+
+---
+
+## Full example — Steam ticket to SpacetimeDB connection
+
+A complete, self-contained node. Drop it in a scene, set `client_id`, call
+`login()`. It requests a Steam WebAPI ticket, races it against a timeout,
+exchanges it, and connects SpacetimeDB with the resulting JWT.
+
+```gdscript
+extends Node
+class_name SteamSpacetimeLogin
+
+# --- config -------------------------------------------------------------
+## SpacetimeAuth client_id for this game. Pull from ProjectSettings/config.
+@export var client_id: String = ""
+## The Steam grant type + the identity string the WebAPI ticket must be bound to.
+const GRANT_TYPE: String = "urn:spacetimeauth:steam-ticket"
+const TICKET_IDENTITY: String = "spacetimeauth"   # required exact value
+const TICKET_TIMEOUT_SECONDS: float = 10.0
+const STEAM_RESULT_OK: int = 1                    # k_EResultOK
+
+signal login_succeeded(id_token: String)
+signal login_failed(reason: String)
+
+
+func login() -> void:
+    if not Engine.has_singleton(&"Steam"):
+        _fail("Steam singleton missing"); return
+    if not Steam.loggedOn():
+        _fail("Steam not logged on (is the client running?)"); return
+    if client_id.is_empty():
+        _fail("client_id not set"); return
+
+    var app_id: int = Steam.getAppID()
+    if app_id <= 0:
+        _fail("Steam app id unavailable"); return
+
+    # 1. Request a WebAPI-scoped ticket bound to the "spacetimeauth" identity.
+    var handle: int = Steam.getAuthTicketForWebApi(TICKET_IDENTITY)
+    if handle == 0:
+        _fail("getAuthTicketForWebApi returned 0"); return
+
+    # 2. Await the ticket callback (with a timeout + handle filtering).
+    var ticket: PackedByteArray = await _await_ticket(handle)
+    if ticket.is_empty():
+        Steam.cancelAuthTicket(handle)
+        _fail("Steam ticket timed out / failed"); return
+
+    # 3. Exchange the ticket for a SpacetimeAuth id_token.
+    var auth := SpacetimeAuth.new()
+    auth.redact_fields.append("steam_ticket")
+    # auth.debug_mode = true            # uncomment for request/response logging
+    add_child(auth)
+    var result := await auth.exchange(
+        GRANT_TYPE,
+        {
+            "steam_ticket": ticket.hex_encode(),
+            "steam_app_id": str(app_id),
+        },
+        client_id,
+    )
+    auth.queue_free()
+    Steam.cancelAuthTicket(handle)      # one-time ticket; always cancel it
+
+    if not result.is_successful():
+        _fail("OIDC exchange failed: %s" % result.error); return
+
+    # 4. (Optional) sanity-check the JWT client-side. NOT a security check —
+    #    the server verifies the signature on connect. Handy for diagnostics.
+    print("JWT claims:\n%s" % JwtHelper.summarize(result.id_token))
+    var jwt_provider_id := String(JwtHelper.decode_payload(result.id_token).get("provider_id", ""))
+    if jwt_provider_id != "" and jwt_provider_id != str(Steam.getSteamID()):
+        push_warning("JWT provider_id (%s) != current SteamID (%s)" % [jwt_provider_id, Steam.getSteamID()])
+
+    login_succeeded.emit(result.id_token)
+
+
+func _fail(reason: String) -> void:
+    push_error("[SteamSpacetimeLogin] %s" % reason)
+    login_failed.emit(reason)
+
+
+# Race Steam's `get_ticket_for_web_api` signal against a deadline. Returns the
+# ticket bytes, or an empty array on timeout / non-OK result. Filters by handle
+# because concurrent ticket requests (Lobbies/Friends flows) share this signal.
+func _await_ticket(requested_handle: int) -> PackedByteArray:
+    var tree := get_tree()
+    if tree == null:
+        return PackedByteArray()
+    var state := {"done": false, "bytes": PackedByteArray()}
+
+    # payload: (auth_ticket:int, result:int, ticket_size:int, ticket_buffer:PackedByteArray)
+    var on_ticket := func(handle: int, code: int, _size: int, buf: PackedByteArray) -> void:
+        if state.done or handle != requested_handle:
+            return
+        state.done = true
+        if code == STEAM_RESULT_OK:
+            state.bytes = buf
+
+    Steam.get_ticket_for_web_api.connect(on_ticket)
+    tree.create_timer(TICKET_TIMEOUT_SECONDS).timeout.connect(func() -> void: state.done = true)
+    while not state.done:
+        await tree.process_frame
+    if Steam.get_ticket_for_web_api.is_connected(on_ticket):
+        Steam.get_ticket_for_web_api.disconnect(on_ticket)
+    return state.bytes
+```
+
+### Connecting to SpacetimeDB with the id_token
+
+Hand the JWT to the SDK as the connection token:
+
+```gdscript
+func _ready() -> void:
+    var login := SteamSpacetimeLogin.new()
+    login.client_id = ProjectSettings.get_setting("spacetimeauth/client_id", "")
+    login.login_succeeded.connect(_on_login_ok)
+    login.login_failed.connect(func(reason: String) -> void: push_error(reason))
+    add_child(login)
+    login.login()
+
+
+func _on_login_ok(id_token: String) -> void:
+    var opts := SpacetimeDBConnectionOptions.new()
+    opts.token = id_token                  # <-- the SpacetimeAuth JWT
+    # opts.compression / opts.threading / opts.one_time_token as needed
+
+    # SpacetimeDBClient.connect_db(host_url, database_name, options)
+    var client: SpacetimeDBClient = $SpacetimeDBClient
+    client.connect_db("http://127.0.0.1:3000", "my_module", opts)
+```
+
+> If your project uses the generated module wrapper (e.g. `SpacetimeDB.MyModule`),
+> route the same `opts` through however it exposes `connect_db`. The only
+> contract that matters here: **set `SpacetimeDBConnectionOptions.token` to
+> `result.id_token`**. A non-empty `token` is used as-is; leave it empty and the
+> SDK falls back to its anonymous token-request path.
+
+---
+
+## Signal-based variant
+
+Prefer signals over `await`? `exchange()` also emits `exchange_completed`:
+
+```gdscript
+var auth := SpacetimeAuth.new()
+auth.redact_fields.append("steam_ticket")
+add_child(auth)
+auth.exchange_completed.connect(func(result: SpacetimeAuth.ExchangeResult) -> void:
+    auth.queue_free()
+    if result.is_successful():
+        _on_login_ok(result.id_token)
+    else:
+        push_error(result.error)
+)
+auth.exchange(GRANT_TYPE, {"steam_ticket": ticket.hex_encode(), "steam_app_id": str(app_id)}, client_id)
+```
+
+---
+
+## Reading claims with `JwtHelper`
+
+`JwtHelper` (`addons/SpacetimeDB/util/jwt_helper.gd`) decodes the JWT **payload**
+for local bookkeeping/diagnostics. It does **not** verify the signature — never
+gate authorization on it client-side; the server verifies on connect.
+
+```gdscript
+JwtHelper.decode_payload(id_token)   # -> Dictionary of claims
+JwtHelper.login_method(id_token)     # -> "steam" / "anonymous" / provider name
+JwtHelper.summarize(id_token)        # -> short multi-line dump for logs
+```
+
+A useful pattern: key your on-disk token cache off `JwtHelper.login_method()` so
+a Steam-issued token can't clobber a different provider's cached token.
+
+---
+
+## Other providers
+
+Same node, different `grant_type` + fields (per the SpacetimeAuth docs):
+
+```gdscript
+# Google Play
+await auth.exchange("urn:spacetimeauth:google-play", {"gpg_authcode": code}, client_id)
+# Epic
+await auth.exchange("urn:spacetimeauth:epic", {"epic_id_token": jwt}, client_id)
+```
+
+Remember to append the credential field name to `redact_fields` if it should be
+kept out of logs.
+
+---
+
+## Troubleshooting
+
+| symptom | cause / fix |
+|---|---|
+| `client_id empty` | `client_id` arg was blank — load it from settings before calling. |
+| `SpacetimeAuth node must be inside the scene tree` | call `add_child(auth)` **before** `exchange()`. |
+| `transport error: CANT_RESOLVE / CANT_CONNECT` | no network / DNS to `auth.spacetimedb.com`; the node already retried `max_attempts`. |
+| `HTTP 400/401` with `allowed_app_ids` / grant errors | Steam app not registered with SpacetimeAuth for the grant, or wrong `steam_app_id` / `client_id`. Body is logged (credentials redacted). |
+| `response missing id_token` | endpoint returned 200 but no `id_token` — check the grant config server-side. |
+| ticket never arrives | `getAuthTicketForWebApi` identity must be exactly `"spacetimeauth"`; ensure Steam is running and `loggedOn()`. |
+| token in logs | append your credential field (e.g. `"steam_ticket"`) to `auth.redact_fields`. |
+
+---
+
+## Key rules recap
+
+- Add the node to the tree **before** `exchange()`; `queue_free()` it after.
+- `cancelAuthTicket(handle)` — the WebAPI ticket is single-use.
+- Ticket identity string is exactly `"spacetimeauth"`.
+- Append provider credential fields to `redact_fields` for log hygiene.
+- `id_token` → `SpacetimeDBConnectionOptions.token`. Empty token = anonymous.
+- `JwtHelper` is for diagnostics only — the server verifies the signature.

--- a/docs/spacetimeauth-godotsteam.md
+++ b/docs/spacetimeauth-godotsteam.md
@@ -22,14 +22,31 @@ getAuthTicketForWebApi   ─▶  exchange(grant_type, fields)  ─▶  POST /oid
 
 ## Prerequisites
 
-1. **SDK addon enabled** (`addons/SpacetimeDB`) — gives you `SpacetimeAuth`,
-   `SpacetimeDBClient`, `SpacetimeDBConnectionOptions`, and `JwtHelper`.
-2. **GodotSteam** installed and `Steam.steamInitEx()` succeeded, with your
-   Steam **App ID** set (`steam_appid.txt` during dev, or the launched app).
-3. A **SpacetimeAuth `client_id`** for your game, and your Steam app registered
-   with SpacetimeAuth for the `steam-ticket` grant. Store the `client_id` in a
-   project setting or config — never hard-code it in a shipped scene you can't
-   rotate.
+### 1. SpacetimeAuth + Steam setup (do this FIRST)
+
+Your `client_id` **only exists after** you configure SpacetimeAuth for Steam —
+there is no client code you can run until this is done. Follow the official guide,
+[SpacetimeAuth › Steam](https://spacetimedb.com/docs/core-concepts/authentication/spacetimeauth/steam),
+which in order is:
+
+1. **Create a Steam Publisher Key** in the Steamworks dashboard — SpacetimeAuth
+   uses it to verify session tickets and read game-ownership.
+2. **Note your Steam App ID(s)** — every app / DLC whose ownership you want checked.
+3. **Configure the SpacetimeAuth dashboard** (Settings): add the Steam Publisher
+   Key and the list of **allowed App IDs**. Only session tickets issued for those
+   app IDs are accepted at exchange time.
+4. **Copy your `client_id`** from your SpacetimeAuth project settings.
+
+Until step 4 you have no `client_id`, and the exchange below cannot run. Store it
+in a project setting / config (e.g. `spacetimeauth/client_id`) — never hard-code
+it in a shipped scene you can't rotate.
+
+### 2. Godot side
+
+- **SDK addon enabled** (`addons/SpacetimeDB`) — gives you `SpacetimeAuth`,
+  `SpacetimeDBClient`, `SpacetimeDBConnectionOptions`, and `JwtHelper`.
+- **GodotSteam** installed and `Steam.steamInitEx()` succeeded, with your Steam
+  **App ID** set (`steam_appid.txt` during dev, or the launched app).
 
 ---
 

--- a/godot-client/addons/SpacetimeDB/nodes/spacetime_auth/spacetime_auth.gd
+++ b/godot-client/addons/SpacetimeDB/nodes/spacetime_auth/spacetime_auth.gd
@@ -1,0 +1,200 @@
+@tool
+class_name SpacetimeAuth extends Node
+
+# Provider-agnostic SpacetimeAuth token exchange.
+#
+# POSTs to the SpacetimeAuth OIDC token endpoint with a `client_id`, a
+# `grant_type`, and a set of provider-specific credential fields, then returns
+# the issued id_token (a JWT you hand to SpacetimeDBClient as the connection
+# token). The node owns its own HTTPRequest child, so callers just add it to the
+# tree and await:
+#
+#     var auth := SpacetimeAuth.new()
+#     add_child(auth)
+#     var result := await auth.exchange(
+#         "steam",                                # grant_type
+#         {"steam_ticket": ticket_hex, "steam_app_id": "480"},  # provider fields
+#         my_client_id,
+#     )
+#     auth.queue_free()
+#     if result.is_successful():
+#         connection_options.token = result.id_token
+#
+# The same result is also emitted via `exchange_completed` for signal-based
+# callers. Build `extra_fields` per provider (e.g. {"gpg_authcode": code} for
+# Google Play, {"epic_id_token": jwt} for Epic); grant-type strings and field
+# names are documented at https://docs.spacetimedb.com/ .
+
+class ExchangeResult extends RefCounted:
+	var id_token: String = ""
+	var expires_in: int = 0
+	var error: String = ""
+
+	func is_successful() -> bool:
+		return error.is_empty()
+
+
+signal exchange_completed(result: ExchangeResult)
+
+const TOKEN_URL_DEFAULT: String = "https://auth.spacetimedb.com/oidc/token"
+
+@export var debug_mode: bool = false
+## OIDC token endpoint. Override for a self-hosted SpacetimeAuth deployment.
+@export var token_url: String = TOKEN_URL_DEFAULT
+## Bounds the network hang on an unreachable endpoint (DNS stall, TLS failure).
+@export var request_timeout_seconds: float = 15.0
+## Total attempts before giving up. Transient failures (transport error / 5xx)
+## are retried; a 2xx/4xx is authoritative and never retried.
+@export var max_attempts: int = 4
+@export var base_retry_delay_seconds: float = 0.5
+@export var max_retry_delay_seconds: float = 4.0
+## Field names whose VALUES are redacted from any error body echoed to the log.
+@export var redact_fields: Array[String] = [
+	"id_token", "access_token", "refresh_token", "token", "code", "ticket", "client_secret",
+]
+
+var _http: HTTPRequest
+
+
+func _print_log(message: String) -> void:
+	if debug_mode:
+		print("[SpacetimeAuth] %s" % message)
+
+
+func _ensure_http() -> void:
+	if _http == null or not is_instance_valid(_http):
+		_http = HTTPRequest.new()
+		_http.timeout = request_timeout_seconds
+		add_child(_http)
+
+
+func exchange(grant_type: String, extra_fields: Dictionary, client_id: String) -> ExchangeResult:
+	var result: ExchangeResult = ExchangeResult.new()
+	if client_id.is_empty():
+		result.error = "client_id empty"
+		exchange_completed.emit(result)
+		return result
+	if not is_inside_tree():
+		result.error = "SpacetimeAuth node must be inside the scene tree before calling exchange()"
+		push_error("[SpacetimeAuth] %s" % result.error)
+		exchange_completed.emit(result)
+		return result
+
+	_ensure_http()
+
+	var parts: PackedStringArray = PackedStringArray()
+	parts.append("client_id=" + client_id.uri_encode())
+	parts.append("grant_type=" + grant_type.uri_encode())
+	for key: String in extra_fields.keys():
+		parts.append("%s=%s" % [key.uri_encode(), String(extra_fields[key]).uri_encode()])
+	var body: String = "&".join(parts)
+	var headers: PackedStringArray = PackedStringArray(
+		["content-type: application/x-www-form-urlencoded"]
+	)
+
+	_print_log("POST %s grant_type=%s client_id=%s (%d bytes)" % [
+		token_url, grant_type, client_id, body.length(),
+	])
+
+	# Retry transient failures with exponential backoff: a request submit error,
+	# no HTTP response (transport-level DNS/connect/timeout), or a 5xx. A 2xx/4xx
+	# is authoritative and breaks out immediately.
+	var response: Array = []
+	for attempt: int in max_attempts:
+		var last: bool = attempt == max_attempts - 1
+		var err: Error = _http.request(token_url, headers, HTTPClient.METHOD_POST, body)
+		if err == OK:
+			response = await _http.request_completed
+			if not is_instance_valid(_http):
+				result.error = "HTTPRequest freed mid-await (node shutdown?)"
+				exchange_completed.emit(result)
+				return result
+			var status_code: int = int(response[1]) if response.size() >= 2 else 0
+			if not (status_code == 0 or status_code >= 500):
+				break
+		if last:
+			if err != OK:
+				result.error = "HTTPRequest.request err=%d" % err
+				push_error("[SpacetimeAuth] %s" % result.error)
+				exchange_completed.emit(result)
+				return result
+			break
+		var delay: float = minf(max_retry_delay_seconds, base_retry_delay_seconds * pow(2.0, float(attempt)))
+		push_warning("[SpacetimeAuth] transient failure (attempt %d/%d), retry in %.1fs" % [
+			attempt + 1, max_attempts, delay,
+		])
+		await get_tree().create_timer(delay).timeout
+
+	if response.size() < 4:
+		result.error = "unexpected request_completed payload size=%d" % response.size()
+		push_error("[SpacetimeAuth] %s" % result.error)
+		exchange_completed.emit(result)
+		return result
+
+	var transport_result: int = int(response[0])
+	var code: int = int(response[1])
+	var body_str: String = PackedByteArray(response[3]).get_string_from_utf8()
+	_print_log("response: transport=%d HTTP=%d" % [transport_result, code])
+
+	# code == 0 means no HTTP response was produced; translate the transport enum
+	# so logs read "CANT_CONNECT" rather than an opaque "HTTP 0".
+	if code == 0:
+		result.error = "transport error: %s (HTTPRequest.Result=%d)" % [
+			_transport_result_name(transport_result), transport_result,
+		]
+		exchange_completed.emit(result)
+		return result
+
+	if code != 200:
+		var redacted: String = _redact_credentials(body_str)
+		result.error = "HTTP %d: %s" % [code, redacted]
+		exchange_completed.emit(result)
+		return result
+
+	var parsed_variant: Variant = JSON.parse_string(body_str)
+	if not (parsed_variant is Dictionary):
+		result.error = "response not JSON object"
+		exchange_completed.emit(result)
+		return result
+	var parsed: Dictionary = parsed_variant
+	result.id_token = String(parsed.get("id_token", ""))
+	result.expires_in = int(parsed.get("expires_in", 0))
+	if result.id_token.is_empty():
+		result.error = "response missing id_token (keys=%s)" % str(parsed.keys())
+	exchange_completed.emit(result)
+	return result
+
+
+# Best-effort scrub of credential-bearing fields from a body before logging it.
+# Handles JSON objects (`"field": "..."` -> `"field": "<redacted>"`) and
+# url-encoded form bodies (`field=...` -> `field=<redacted>`). Not a security
+# boundary — just keeps single-use tickets / tokens out of log files.
+func _redact_credentials(body: String) -> String:
+	var redacted: String = body
+	for field: String in redact_fields:
+		var json_re: RegEx = RegEx.new()
+		json_re.compile('"%s"\\s*:\\s*"[^"]*"' % field)
+		redacted = json_re.sub(redacted, '"%s": "<redacted>"' % field, true)
+		var form_re: RegEx = RegEx.new()
+		form_re.compile("%s=[^&]*" % field)
+		redacted = form_re.sub(redacted, "%s=<redacted>" % field, true)
+	return redacted
+
+
+static func _transport_result_name(rc: int) -> String:
+	match rc:
+		HTTPRequest.RESULT_SUCCESS: return "SUCCESS"
+		HTTPRequest.RESULT_CHUNKED_BODY_SIZE_MISMATCH: return "CHUNKED_BODY_SIZE_MISMATCH"
+		HTTPRequest.RESULT_CANT_CONNECT: return "CANT_CONNECT"
+		HTTPRequest.RESULT_CANT_RESOLVE: return "CANT_RESOLVE"
+		HTTPRequest.RESULT_CONNECTION_ERROR: return "CONNECTION_ERROR"
+		HTTPRequest.RESULT_TLS_HANDSHAKE_ERROR: return "TLS_HANDSHAKE_ERROR"
+		HTTPRequest.RESULT_NO_RESPONSE: return "NO_RESPONSE"
+		HTTPRequest.RESULT_BODY_SIZE_LIMIT_EXCEEDED: return "BODY_SIZE_LIMIT_EXCEEDED"
+		HTTPRequest.RESULT_BODY_DECOMPRESS_FAILED: return "BODY_DECOMPRESS_FAILED"
+		HTTPRequest.RESULT_REQUEST_FAILED: return "REQUEST_FAILED"
+		HTTPRequest.RESULT_DOWNLOAD_FILE_CANT_OPEN: return "DOWNLOAD_FILE_CANT_OPEN"
+		HTTPRequest.RESULT_DOWNLOAD_FILE_WRITE_ERROR: return "DOWNLOAD_FILE_WRITE_ERROR"
+		HTTPRequest.RESULT_REDIRECT_LIMIT_REACHED: return "REDIRECT_LIMIT_REACHED"
+		HTTPRequest.RESULT_TIMEOUT: return "TIMEOUT"
+		_: return "UNKNOWN"

--- a/godot-client/addons/SpacetimeDB/nodes/spacetime_auth/spacetime_auth.gd.uid
+++ b/godot-client/addons/SpacetimeDB/nodes/spacetime_auth/spacetime_auth.gd.uid
@@ -1,0 +1,1 @@
+uid://spauthx9qm2k

--- a/godot-client/addons/SpacetimeDB/util/jwt_helper.gd
+++ b/godot-client/addons/SpacetimeDB/util/jwt_helper.gd
@@ -1,0 +1,55 @@
+class_name JwtHelper
+
+# Tiny JWT payload decoder. JWT = base64url(header).base64url(payload).signature.
+#
+# Handy for reading claims out of a SpacetimeAuth id_token client-side, e.g. to
+# key a per-identity token cache off the JWT's `login_method` claim so tokens
+# from different login providers don't overwrite each other.
+#
+# SECURITY: the payload is NOT signature-verified here. Do NOT use this for any
+# authorization decision on the client — the SpacetimeDB server verifies the
+# signature on connect. This is purely for reading claims for local bookkeeping
+# and diagnostics.
+
+
+static func decode_payload(jwt: String) -> Dictionary:
+	var parts: PackedStringArray = jwt.split(".")
+	if parts.size() < 2:
+		return {}
+	var payload_b64url: String = parts[1]
+	# base64url -> base64: the URL-safe alphabet uses `-_` instead of `+/` and drops padding.
+	var padded: String = payload_b64url.replace("-", "+").replace("_", "/")
+	while padded.length() % 4 != 0:
+		padded += "="
+	var bytes: PackedByteArray = Marshalls.base64_to_raw(padded)
+	if bytes.is_empty():
+		return {}
+	# A JWT payload that decodes to a JSON array / scalar / null would fail a
+	# direct typed-Dictionary assignment, so parse to Variant and guard.
+	var parsed: Variant = JSON.parse_string(bytes.get_string_from_utf8())
+	if not (parsed is Dictionary):
+		return {}
+	return parsed
+
+
+# `login_method` is set by SpacetimeAuth (e.g. "anonymous" or a provider name).
+# Returns "" for an empty / malformed JWT.
+static func login_method(jwt: String) -> String:
+	if jwt.is_empty():
+		return ""
+	return String(decode_payload(jwt).get("login_method", ""))
+
+
+# Human-readable dump of common claims for diagnostic logging. Returns
+# "<empty>" / "<malformed>" or a multi-line string of the claims that are present.
+static func summarize(jwt: String) -> String:
+	if jwt.is_empty():
+		return "<empty>"
+	var payload: Dictionary = decode_payload(jwt)
+	if payload.is_empty():
+		return "<malformed jwt or non-json payload>"
+	var lines: PackedStringArray = PackedStringArray()
+	for key: String in ["iss", "sub", "aud", "login_method", "provider_id", "preferred_username", "exp", "iat"]:
+		if payload.has(key):
+			lines.append("    %s = %s" % [key, payload[key]])
+	return "\n".join(lines)

--- a/godot-client/addons/SpacetimeDB/util/jwt_helper.gd.uid
+++ b/godot-client/addons/SpacetimeDB/util/jwt_helper.gd.uid
@@ -1,0 +1,1 @@
+uid://jwthlp7x2q4m


### PR DESCRIPTION
## Summary

Add first-class SDK components for authenticating a SpacetimeDB connection via
the **SpacetimeAuth OIDC flow**:

- `nodes/spacetime_auth/spacetime_auth.gd` — `class_name SpacetimeAuth`, a Node
  that exchanges a platform credential for a SpacetimeAuth-issued `id_token`.
- `util/jwt_helper.gd` — `class_name JwtHelper`, a static utility for decoding a
  JWT payload client-side (to read claims for local bookkeeping / diagnostics).

## Motivation

SpacetimeDB connections authenticate with a token. For anonymous play the SDK's
built-in `/v1/identity` flow is enough, but for **provider login** (Steam, Google
Play, Epic, ...) the client needs to turn a platform credential into a
SpacetimeAuth-issued `id_token` (a JWT) via SpacetimeAuth's OIDC token endpoint,
then connect with that token. That exchange is the same shape for every provider
— only the `grant_type` and the credential field names differ — so it belongs in
the SDK rather than being re-implemented per game.

## The OIDC flow this enables

1. The game obtains a provider credential (e.g. a Steam session ticket, a Google
   Play server auth code, an Epic id_token).
2. `SpacetimeAuth.exchange(grant_type, extra_fields, client_id)` POSTs it,
   form-encoded, to the SpacetimeAuth OIDC token endpoint
   (`https://auth.spacetimedb.com/oidc/token` by default).
3. On success it returns the issued `id_token` (JWT) + `expires_in`.
4. The game hands that `id_token` to `SpacetimeDBClient` as the connection token
   (`SpacetimeDBConnectionOptions.token`) and connects. The server verifies the
   JWT signature.

## Design decision — Node (not a static class)

The original implementation in our game was a `class_name` with **static**
methods that required the caller to pass a `host: Node` so a transient
`HTTPRequest` could be parented somewhere (a static/`RefCounted` context can't own
scene-tree children or timers).

**This PR redesigns it as a `Node`**, because a Node is more idiomatic for the
SDK and removes the awkward `host` parameter:

- The node owns its own `HTTPRequest` child, so there's no `host` to thread
  through — the caller just `add_child`s the node.
- It matches the addon's existing node convention (`nodes/row_receiver/`):
  `@tool` + `class_name` + tree-resident, no `add_custom_type` registration.
- Timers for retry backoff use the node's own `get_tree()`.

The API is both awaitable and signal-based, matching how the addon already mixes
`await` and signals:

```gdscript
var auth := SpacetimeAuth.new()
add_child(auth)
var result := await auth.exchange(
    "steam",                                              # grant_type
    {"steam_ticket": ticket_hex, "steam_app_id": "480"}, # provider-specific fields
    my_client_id,
)
auth.queue_free()
if result.is_successful():
    connection_options.token = result.id_token
# ...or connect the `exchange_completed(result)` signal instead of awaiting.
```

`JwtHelper` stays a **static utility class** — it's pure functions over a string
(base64url decode + claim reads) with no state or scene-tree needs — placed under
a new `util/` folder.

## What changed (all new files)

- `nodes/spacetime_auth/spacetime_auth.gd` (+ `.gd.uid`)
  - `SpacetimeAuth extends Node`, owns its `HTTPRequest` child.
  - `exchange(grant_type, extra_fields, client_id) -> ExchangeResult` coroutine;
    also emits `exchange_completed(result)`.
  - Nested `ExchangeResult` (`id_token`, `expires_in`, `error`,
    `is_successful()`).
  - Retries transient failures (submit error / no HTTP response / 5xx) with
    exponential backoff; endpoint URL, timeout, attempt count, and delays are
    exported and configurable.
  - Credential-bearing fields are redacted from any error body echoed to the log
    (`redact_fields`, exported). Verbose logging gated behind `debug_mode`.
  - `_transport_result_name()` maps `HTTPRequest.RESULT_*` to a readable string
    for diagnostics.
- `util/jwt_helper.gd` (+ `.gd.uid`)
  - `decode_payload(jwt) -> Dictionary`, `login_method(jwt) -> String`,
    `summarize(jwt) -> String`.
  - **Security:** the payload is NOT signature-verified — for local
    bookkeeping/diagnostics only. The server verifies the signature on connect.

All provider-specific (Steam/etc.) comments and special-cases from the original
game code were removed; the components are provider-agnostic.

## Testing notes

  The logic is a port of code running in production in our game, generalized.
- Suggested checks:
  - `JwtHelper.decode_payload` on a known JWT returns the expected claims;
    malformed input returns `{}`.
  - `SpacetimeAuth.exchange` against a real SpacetimeAuth client_id returns an
    `id_token`; a bad credential returns a non-empty `error` (4xx, not retried);
    an unreachable endpoint retries then returns a transport error.

## Open questions for the maintainer

- **Placement:** `nodes/spacetime_auth/` for the node and a new `util/` folder for
  the JWT helper. If you'd rather the helper live in `core/`, it's a one-line
  move.
- **Node icon:** `nodes/row_receiver/` ships an `@icon` SVG; this node has none
  (to avoid committing a fabricated `.import`). Happy to add one if you want it to
  appear with a custom icon in the Create-Node dialog.
- **Docs:** should this get an entry in `docs/` (e.g. an auth quickstart)? I can
  add one to this PR if desired, and also examples with Godotsteam.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
