### PR TITLE
Don't quit the SceneTree from SpacetimeDBConnection._exit_tree

### DIFF
--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_connection.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_connection.gd
@@ -231,8 +231,13 @@ func _handle_game_closing():
 	get_tree().quit()
 
 func _exit_tree() -> void:
+	# Disconnect on node removal, but never get_tree().quit() here — _exit_tree
+	# fires whenever the connection node is freed (a transient client, a scene
+	# swap), so quitting takes down the whole app. Real app-close is handled by
+	# the notifications below.
 	_print_log("SpacetimeDBConnection: Exit Tree")
-	_handle_game_closing()
+	if _websocket != null and _websocket.get_ready_state() != WebSocketPeer.STATE_CLOSED:
+		disconnect_from_server()
 
 func _notification(what: int) -> void:
 	match what:


### PR DESCRIPTION
## Problem
`SpacetimeDBConnection._exit_tree()` calls `_handle_game_closing()`, which ends in `get_tree().quit()`. But `_exit_tree` runs on **any** node removal — not just app shutdown. So freeing a connection node (a transient/short-lived client that connects, does a task, and cleans itself up; a scene swap; reparenting; the autoload torn down on scene reload) quits the **entire game**.

Repro: create a second, short-lived `SpacetimeDBClient`, let it connect and do some work, then `queue_free()` it while the main client keeps running — the whole app quits.

## Fix
`_exit_tree` now disconnects gracefully (closes the socket if still open) but does **not** quit the tree. Genuine application close stays handled by `NOTIFICATION_WM_CLOSE_REQUEST` / `NOTIFICATION_CRASH`, which already call `_handle_game_closing()`.

## Testing
Verified in a Godot 4.7 project: a transient client that connects, fires a burst of reducers, and frees itself no longer takes the main game down — the main client stays connected and the game keeps running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
