### PR TITLE
bsatn serializer simplification and removal of Callables

### DIFF
--- a/godot-client/addons/SpacetimeDB/core/bsatn_serializer.gd
+++ b/godot-client/addons/SpacetimeDB/core/bsatn_serializer.gd
@@ -4,17 +4,6 @@ const IDENTITY_SIZE := 32
 const CONNECTION_ID_SIZE := 16
 const U128_SIZE := 16
 
-const NATIVE_ARRAYLIKE := [
-	"Vector2",
-	"Vector2i",
-	"Vector3",
-	"Vector3i",
-	"Vector4",
-	"Vector4i",
-	"Quaternion",
-	"Color",
-]
-
 var _last_error: String = ""
 var _spb: StreamPeerBuffer
 var _schema: SpacetimeDBSchema
@@ -59,17 +48,6 @@ func _log(msg: String) -> void:
 		print(msg)
 
 
-func _get_value_class_name(value: Variant) -> String:
-	if value is Resource:
-		var script :GDScript= value.get_script()
-		if script and script.get_global_name() != "":
-			return script.get_global_name()
-		return value.resource_path
-	if typeof(value) == TYPE_OBJECT:
-		return value.get_class()
-	return type_string(typeof(value))
-
-
 func _generate_default_type(bsatn_type_name: String) -> Variant:
 	match String(bsatn_type_name):
 		"I8", "I16", "I32", "I64", "U8", "U16", "U32", "U64":
@@ -98,50 +76,6 @@ func _generate_default_type(bsatn_type_name: String) -> Variant:
 			return Quaternion.IDENTITY
 		_:
 			return null
-
-
-func _get_primitive_writer_from_bsatn_type(bsatn_type_str: String) -> Callable:
-	match bsatn_type_str:
-		"U128":
-			return Callable(self, "write_u128")
-		"U64":
-			return Callable(self, "write_u64_le")
-		"I64":
-			return Callable(self, "write_i64_le")
-		"F64":
-			return Callable(self, "write_f64_le")
-		"U32":
-			return Callable(self, "write_u32_le")
-		"I32":
-			return Callable(self, "write_i32_le")
-		"F32":
-			return Callable(self, "write_f32_le")
-		"U16":
-			return Callable(self, "write_u16_le")
-		"I16":
-			return Callable(self, "write_i16_le")
-		"U8":
-			return Callable(self, "write_u8")
-		"I8":
-			return Callable(self, "write_i8")
-		"__identity__":
-			return Callable(self, "write_identity")
-		"__connection_id__":
-			return Callable(self, "write_connection_id")
-		"__timestamp_micros_since_unix_epoch__":
-			return Callable(self, "write_timestamp")
-		"__uuid__":
-			return Callable(self, "write_hex_string")
-		"scheduled_at":
-			return Callable(self, "write_timestamp")
-		"Bool":
-			return Callable(self, "write_bool")
-		"String":
-			return Callable(self, "write_string_with_u32_len")
-		"vec_U8":
-			return Callable(self, "write_vec_u8")
-		_:
-			return Callable()
 
 
 func write_i8(v: int) -> void:
@@ -216,6 +150,7 @@ func write_bytes(v: PackedByteArray) -> void:
 	if result != OK:
 		_set_error("StreamPeerBuffer.put_data failed with code %d" % result)
 
+
 func write_hex_string(v: String) -> void:
 	if v.is_empty():
 		return
@@ -224,6 +159,7 @@ func write_hex_string(v: String) -> void:
 	var result := _spb.put_data(v2)
 	if result != OK:
 		_set_error("StreamPeerBuffer.put_data failed with code %d" % result)
+
 
 func write_u128(v: PackedByteArray) -> void:
 	if v == null or v.size() != U128_SIZE:
@@ -310,7 +246,10 @@ func write_rust_enum(rust_enum: RustEnum) -> void:
 
 	if sub_class.begins_with("vec"):
 		if data is not Array:
-			_set_error("Rust enum variant expects Array but got %s" % _get_value_class_name(data))
+			_set_error(
+				"Rust enum variant expects Array but got %s"
+				% type_string(typeof(data))
+			)
 			return
 		var vec_type := sub_class.right(-4)
 		if vec_type.begins_with("opt"):
@@ -320,7 +259,10 @@ func write_rust_enum(rust_enum: RustEnum) -> void:
 
 	if sub_class.begins_with("opt"):
 		if not data is Option:
-			_set_error("Rust enum variant expects Option but got %s" % _get_value_class_name(data))
+			_set_error(
+				"Rust enum variant expects Option but got %s"
+				% type_string(typeof(data))
+			)
 			return
 		var opt_type := sub_class.right(-4)
 		if opt_type.begins_with("vec"):
@@ -334,7 +276,7 @@ func write_rust_enum(rust_enum: RustEnum) -> void:
 		_write_value_from_bsatn_type(data, sub_class, &"")
 
 
-func write_native_arraylike(v: Variant, bsatn_type: String, prop: Dictionary) -> void:
+func write_native_arraylike(v: Variant, bsatn_type: String, prop_name: StringName) -> void:
 	var components: Array = []
 	match typeof(v):
 		TYPE_VECTOR2:
@@ -354,10 +296,10 @@ func write_native_arraylike(v: Variant, bsatn_type: String, prop: Dictionary) ->
 		TYPE_COLOR:
 			components = [v.r, v.g, v.b, v.a]
 		_:
-			_set_error("Unsupported native arraylike type '%s' for '%s'" % [
-				type_string(typeof(v)),
-				prop.name,
-			])
+			_set_error(
+				"Unsupported native arraylike type '%s' for '%s'"
+				% [type_string(typeof(v)), prop_name]
+			)
 			return
 
 	var component_types: Array[String] = []
@@ -384,18 +326,18 @@ func write_native_arraylike(v: Variant, bsatn_type: String, prop: Dictionary) ->
 				component_types = ["F32", "F32", "F32", "F32"]
 
 	if component_types.size() != components.size():
-		_set_error("Invalid component count for '%s'" % prop.name)
+		_set_error("Invalid component count for '%s'" % prop_name)
 		return
 
 	for i in range(components.size()):
 		_write_value_from_bsatn_type(
 			components[i],
 			component_types[i],
-			"%s[%d]" % [prop.name, i]
+			"%s[%d]" % [prop_name, i]
 		)
 
 
-func write_array(v: Array, bsatn_type: String, prop: Dictionary) -> void:
+func write_array(v: Array, bsatn_type: String, prop_name: StringName) -> void:
 	write_u32_le(v.size())
 	if has_error() or v.is_empty():
 		return
@@ -407,7 +349,7 @@ func write_array(v: Array, bsatn_type: String, prop: Dictionary) -> void:
 		element_type = bsatn_type
 
 	for i in range(v.size()):
-		_write_value_from_bsatn_type(v[i], element_type, "%s[%d]" % [prop.name, i])
+		_write_value_from_bsatn_type(v[i], element_type, "%s[%d]" % [prop_name, i])
 
 
 func write_nested_resource(resource: Resource) -> void:
@@ -415,59 +357,6 @@ func write_nested_resource(resource: Resource) -> void:
 		_set_error("Cannot serialize null resource")
 		return
 	_serialize_resource_fields(resource)
-
-
-func _call_writer_callable(
-	writer_callable: Callable,
-	value: Variant,
-	bsatn_type: String,
-	prop: Dictionary
-) -> void:
-	match writer_callable.get_method():
-		"write_array", "write_option", "write_native_arraylike":
-			writer_callable.call(value, bsatn_type, prop)
-		"write_nested_resource":
-			writer_callable.call(value)
-		_:
-			writer_callable.call(value)
-
-
-func _get_writer_callable_for_property(
-	prop: Dictionary,
-	bsatn_type_str: String
-) -> Callable:
-	var prop_type: Variant.Type = prop.type
-
-	if prop.class_name == &"Option":
-		return Callable(self, "write_option")
-	if prop.class_name == &"RustEnum":
-		return Callable(self, "write_rust_enum")
-
-	if prop_type == TYPE_ARRAY:
-		return Callable(self, "write_array")
-	if NATIVE_ARRAYLIKE.has(prop.class_name):
-		return Callable(self, "write_native_arraylike")
-
-	if not bsatn_type_str.is_empty():
-		var primitive := _get_primitive_writer_from_bsatn_type(bsatn_type_str)
-		if primitive.is_valid():
-			return primitive
-
-	match prop_type:
-		TYPE_BOOL:
-			return Callable(self, "write_bool")
-		TYPE_INT:
-			return Callable(self, "write_i64_le")
-		TYPE_FLOAT:
-			return Callable(self, "write_f32_le")
-		TYPE_STRING:
-			return Callable(self, "write_string_with_u32_len")
-		TYPE_PACKED_BYTE_ARRAY:
-			return Callable(self, "write_vec_u8")
-		TYPE_OBJECT:
-			return Callable(self, "write_nested_resource")
-		_:
-			return Callable()
 
 
 func _write_value_from_bsatn_type(
@@ -483,37 +372,106 @@ func _write_value_from_bsatn_type(
 		return not has_error()
 
 	if bsatn_type_str.begins_with("vec_") and typeof(value) == TYPE_ARRAY:
-		write_array(
-			value,
-			bsatn_type_str,
-			{"name": context_name, "type": TYPE_ARRAY, "class_name": &""}
-		)
+		write_array(value, bsatn_type_str, context_name)
 		return not has_error()
 
-	var primitive := _get_primitive_writer_from_bsatn_type(bsatn_type_str)
-	if primitive.is_valid():
-		primitive.call(value)
-		return not has_error()
+	match bsatn_type_str:
+		"U128":
+			write_u128(value)
+			return not has_error()
+		"U64":
+			write_u64_le(value)
+			return not has_error()
+		"I64":
+			write_i64_le(value)
+			return not has_error()
+		"F64":
+			write_f64_le(value)
+			return not has_error()
+		"U32":
+			write_u32_le(value)
+			return not has_error()
+		"I32":
+			write_i32_le(value)
+			return not has_error()
+		"F32":
+			write_f32_le(value)
+			return not has_error()
+		"U16":
+			write_u16_le(value)
+			return not has_error()
+		"I16":
+			write_i16_le(value)
+			return not has_error()
+		"U8":
+			write_u8(value)
+			return not has_error()
+		"I8":
+			write_i8(value)
+			return not has_error()
+		"__identity__":
+			write_identity(value)
+			return not has_error()
+		"__connection_id__":
+			write_connection_id(value)
+			return not has_error()
+		"__timestamp_micros_since_unix_epoch__", "scheduled_at":
+			write_timestamp(value)
+			return not has_error()
+		"__uuid__":
+			write_hex_string(value)
+			return not has_error()
+		"Bool":
+			write_bool(value)
+			return not has_error()
+		"String":
+			write_string_with_u32_len(value)
+			return not has_error()
+		"vec_U8":
+			write_vec_u8(value)
+			return not has_error()
 
-	var prop_sim := {
-		"name": context_name,
-		"type": typeof(value),
-		"class_name": _get_value_class_name(value),
-		"usage": PROPERTY_USAGE_STORAGE,
-		"hint": 0,
-		"hint_string": "",
-	}
-
-	var writer := _get_writer_callable_for_property(prop_sim, bsatn_type_str)
-	if not writer.is_valid():
-		_set_error("Unsupported BSATN type '%s' for '%s'" % [
-			bsatn_type_str,
-			context_name,
-		])
-		return false
-
-	_call_writer_callable(writer, value, bsatn_type_str, prop_sim)
-	return not has_error()
+	var value_type := typeof(value)
+	match value_type:
+		TYPE_VECTOR2, TYPE_VECTOR2I, TYPE_VECTOR3, TYPE_VECTOR3I, TYPE_VECTOR4, TYPE_VECTOR4I, TYPE_QUATERNION, TYPE_COLOR:
+			write_native_arraylike(value, bsatn_type_str, context_name)
+			return not has_error()
+		TYPE_ARRAY:
+			write_array(value, bsatn_type_str, context_name)
+			return not has_error()
+		TYPE_BOOL:
+			write_bool(value)
+			return not has_error()
+		TYPE_INT:
+			write_i64_le(value)
+			return not has_error()
+		TYPE_FLOAT:
+			write_f32_le(value)
+			return not has_error()
+		TYPE_STRING, TYPE_STRING_NAME:
+			write_string_with_u32_len(value)
+			return not has_error()
+		TYPE_PACKED_BYTE_ARRAY:
+			write_vec_u8(value)
+			return not has_error()
+		TYPE_OBJECT:
+			if value is Option:
+				write_option(value, bsatn_type_str, context_name)
+				return not has_error()
+			if value is Resource:
+				write_nested_resource(value)
+				return not has_error()
+			_set_error(
+				"Unsupported object type '%s' for '%s'"
+				% [type_string(value_type), context_name]
+			)
+			return false
+		_:
+			_set_error(
+				"Unsupported BSATN type '%s' for '%s'"
+				% [bsatn_type_str, context_name]
+			)
+			return false
 
 
 func _serialize_resource_fields(resource: Resource) -> bool:
@@ -558,13 +516,6 @@ func _serialize_arguments(
 		var bsatn_type := ""
 		if i < bsatn_types.size():
 			bsatn_type = String(bsatn_types[i])
-
-		#if debug_mode:
-			#_log("DEBUG: _serialize_arguments: arg %d type=%s bsatn=%s" % [
-				#i,
-				#_get_value_class_name(arg_value),
-				#bsatn_type,
-			#])
 
 		if not _write_value_from_bsatn_type(arg_value, bsatn_type, "arg[%d]" % i):
 			_spb = original_spb


### PR DESCRIPTION
simple rewrite of the bsatn serializer to remove Callables and make it simpler to add edge cases.
some of the match cases can probably be removed.