### PR TITLE
added clear saved token function

### DIFF
--- a/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
+++ b/godot-client/addons/SpacetimeDB/core/spacetimedb_client.gd
@@ -193,6 +193,15 @@ func _save_token(token_to_save: String):
 	else:
 		printerr("SpacetimeDBClient: Failed to save token to path: ", token_save_path)
 
+func _clear_saved_token():
+	var file := FileAccess.open(token_save_path, FileAccess.WRITE)
+	if file:
+		file.store_string("")
+		file.close()
+	else:
+		printerr("SpacetimeDBClient: Failed to save token to path: ", token_save_path)
+
+
 # --- WebSocket Message Handling ---
 func _process(_delta: float) -> void:
 	if use_threading and is_connected_db():

--- a/godot-client/main.gd
+++ b/godot-client/main.gd
@@ -4,7 +4,7 @@ func _ready() -> void:
 	var options := SpacetimeDBConnectionOptions.new()
 
 	options.one_time_token = true # <--- anonymous-like. set to false to persist
-	options.debug_mode = true # <--- enables lots of additional debug prints and warnings
+	options.debug_mode = false # <--- enables lots of additional debug prints and warnings
 	options.compression = SpacetimeDBConnection.CompressionPreference.GZIP
 	options.threading = false
 	options.monitor_mode = true
@@ -16,6 +16,7 @@ func _ready() -> void:
 
 	SpacetimeDB.Main.connect_db( # WARNING <--- replace 'Main' with your module name
 		"http://127.0.0.1:3000", # WARNING <--- replace it with your url
+		#"https://maincloud.spacetimedb.com",
 		"main", # WARNING <--- replace it with your database name
 		options
 	)

--- a/godot-client/scenes/unrendered_integration_test.tscn
+++ b/godot-client/scenes/unrendered_integration_test.tscn
@@ -7,7 +7,7 @@
 [ext_resource type="Script" uid="uid://6asbt4f8qu6s" path="res://spacetime_bindings/schema/types/main_test_enum.gd" id="5_7lrkc"]
 [ext_resource type="Script" uid="uid://5cko2kja42f7" path="res://spacetime_bindings/schema/types/main_test_type.gd" id="6_2vwu8"]
 
-[sub_resource type="Resource" id="Resource_rv3td"]
+[sub_resource type="Resource" id="Resource_i1b4k"]
 script = ExtResource("4_i1b4k")
 metadata/_custom_type_script = "uid://bdyg80vfb67vt"
 
@@ -38,7 +38,7 @@ script = ExtResource("2_iikab")
 
 [node name="Receiver [MainTestTableDatatypes]" type="Node" parent="VBoxContainer/RichTextLabel" unique_id=922586806]
 script = ExtResource("3_i1b4k")
-table_to_receive = SubResource("Resource_rv3td")
+table_to_receive = SubResource("Resource_i1b4k")
 selected_table_name = "test_table_datatypes"
 metadata/_custom_type_script = "uid://jvk6ou7i2d4s"
 


### PR DESCRIPTION
adds a clear saved token function to the spacetimedb_client script that makes it easier to remove the old token without explicitly using "one time token" to replace the old one.