### PR TITLE
db load and saving on the client

### DIFF
--- a/godot-client/addons/SpacetimeDB/core/local_database_im_export.gd
+++ b/godot-client/addons/SpacetimeDB/core/local_database_im_export.gd
@@ -1,0 +1,25 @@
+extends Resource
+class_name DBImExporter
+
+@export var db_data: Dictionary[String,Array]
+
+static func load_db_data(local_db: LocalDatabase, load_folder: String, table_name: StringName)-> Error:
+	if not FileAccess.file_exists(load_folder+"/"+table_name+".tres"):
+		return Error.ERR_FILE_NOT_FOUND
+	var res : DBImExporter= ResourceLoader.load(load_folder+"/"+table_name+".tres", "DBImExporter")
+	var table_inserts: TableUpdateData = TableUpdateData.new()
+	table_inserts.table_name = table_name
+	table_inserts.inserts.assign(res.db_data[table_name])
+	table_inserts.num_rows = table_inserts.inserts.size()
+	local_db.apply_table_update(table_inserts)
+	return OK
+
+static func save_db_data(local_db: LocalDatabase, save_folder: String, table_name: StringName)-> Error:
+	if not DirAccess.dir_exists_absolute(save_folder):
+		var err = DirAccess.make_dir_recursive_absolute(save_folder)
+		if err != OK:
+			return err
+	var res := DBImExporter.new()
+	var rows := local_db.get_all_rows(table_name)
+	res.db_data.set(table_name, rows)
+	return ResourceSaver.save(res,save_folder+"/"+table_name+".tres")

--- a/godot-client/addons/SpacetimeDB/core/local_database_im_export.gd.uid
+++ b/godot-client/addons/SpacetimeDB/core/local_database_im_export.gd.uid
@@ -1,0 +1,1 @@
+uid://cqhwt3gdr0ien

--- a/godot-client/example_code/integration_tests.gd
+++ b/godot-client/example_code/integration_tests.gd
@@ -35,7 +35,9 @@ func _on_spacetimedb_connected(identity: PackedByteArray, _token: String) -> voi
 	var sub := SpacetimeDB.Main.subscribe(query_string)
 	sub.applied.connect(func() -> void:
 		print("User Subscription Applied")
+		print(error_string(DBImExporter.save_db_data(SpacetimeDB.Main._local_db, "user://db_data", "user")))
 		await get_tree().create_timer(3).timeout
+		print(error_string(DBImExporter.load_db_data(SpacetimeDB.Main._local_db, "user://db_data", "user")))
 		sub.unsubscribe()
 		)
 	sub.end.connect(func() -> void:

--- a/godot-client/scenes/integration_tests.tscn
+++ b/godot-client/scenes/integration_tests.tscn
@@ -34,7 +34,6 @@ Label/styles/normal = SubResource("StyleBoxTexture_m5x7f")
 
 [sub_resource type="Resource" id="Resource_l1dmy"]
 script = ExtResource("4_ruhfi")
-uuid = PackedByteArray()
 metadata/_custom_type_script = "uid://mjoi04hxqdfp"
 
 [sub_resource type="Resource" id="Resource_3ljp4"]


### PR DESCRIPTION
this allows to save and load the client cache to disk and load it back into the db. this is done on a per table basis for more granular control.
this is useful for static data that you might not want to download everytime the client connects.
opening a subscription on the loaded table will still download and overwrite all the data as the server doesn't know that the client already has the data.